### PR TITLE
fix: disable preview for return type + cast fix

### DIFF
--- a/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/MethodHandleElementVisitor.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/MethodHandleElementVisitor.kt
@@ -9,13 +9,12 @@ import javax.swing.SwingUtilities
 
 class MethodHandleElementVisitor : JavaRecursiveElementWalkingVisitor() {
     private val typeData = TypeData()
-    override fun visitMethod(method: PsiMethod?) {
-        if (method == null || method.body == null) return
+    override fun visitMethod(method: PsiMethod) {
+        if (method.body == null) return
         scanElement(method.body!!)
     }
 
-    override fun visitClassInitializer(initializer: PsiClassInitializer?) {
-        if (initializer == null) return
+    override fun visitClassInitializer(initializer: PsiClassInitializer) {
         scanElement(initializer.body)
     }
 

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleCreationInspection.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleCreationInspection.kt
@@ -35,7 +35,7 @@ class MethodHandleCreationInspection: LocalInspectionTool() {
                 problemsHolder.registerProblem(
                     expression.methodExpression as PsiExpression,
                     MethodHandleBundle.message("problem.invocation.arguments.wrong.types",
-                        parameters.map { it.presentableText },
+                        type.signature.parameters.map { it.presentableText },
                         expression.argumentList.expressionTypes.map { it.presentableText }
                     ),
                     ProblemHighlightType.GENERIC_ERROR_OR_WARNING

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleInvokeInspection.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleInvokeInspection.kt
@@ -128,5 +128,8 @@ class MethodHandleInvokeInspection: LocalInspectionTool() {
             handler(project, FileEditorManager.getInstance(project).selectedTextEditor, expr)
         }
 
+        // Disable preview for now, as it throws exceptions in its current state
+        override fun getFileModifierForPreview(target: PsiFile) = null
+
     }
 }


### PR DESCRIPTION
Running with IJ 2022.3, the preview threw an exception - so let's disable it for now.
Also fixes compilation bugs with IJ 2022.3 and a minor output bug.