### PR TITLE
fix: Assignment after phi resulting in Bottom type

### DIFF
--- a/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
@@ -62,7 +62,7 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, private val typeData: Ty
             is PsiDeclarationStatement -> instruction.variable.initializer!!
             else -> TODO("Not supported: ${element.javaClass}")
         }
-        val mhType = resolveMhType(expression, block)
+        val mhType = typeData[expression] ?: resolveMhType(expression, block)
         mhType?.let { typeData[expression] = it }
         ssaConstruction.writeVariable(instruction.variable, block, Holder(mhType ?: Bot))
         if (mhType != null) {


### PR DESCRIPTION
Previously, we resolved the type of expressions in assignments *again* if they already had a type assigned before.
In case of phis, this means that we would need to merge the incoming types again, which doesn't happen.

However, we can simply use the type already found for an expression, improving performance additionally to resolving types properly.

Example code that triggered the bug:

```java
    void m() {
        MethodType mt;
        try {
            mt = MethodType.methodType(void.class);
        } catch (Exception e) {
            mt = MethodType.methodType(void.class);
        }
        MethodType ft = mt; // ft becomes Bottom here
    }
```