### PR TITLE
feat: Support directly initialized final fields

### DIFF
--- a/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/MethodHandleElementVisitor.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/MethodHandleElementVisitor.kt
@@ -18,6 +18,15 @@ class MethodHandleElementVisitor : JavaRecursiveElementWalkingVisitor() {
         scanElement(initializer.body)
     }
 
+    override fun visitField(field: PsiField?) {
+        if (field == null) return
+        if (field.initializer == null) return
+        val factory = JavaPsiFacade.getElementFactory(field.project)
+        val fakeMethod = factory.createMethodFromText("void $$$$() { ${field.type.canonicalText} ${field.name} = ${field.initializer!!.text}; }", field)
+        scanElement(fakeMethod.body!!)
+        typeData[field] = typeData[fakeMethod.body!!.statements.first()] ?: return
+    }
+
     private fun scanElement(body: PsiElement) {
         val controlFlowFactory = ControlFlowFactory.getInstance(body.project)
         val controlFlow: ControlFlow

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
@@ -62,6 +62,7 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, private val typeData: Ty
         val expression = when (val element = controlFlow.getElement(index)) {
             is PsiAssignmentExpression -> element.rExpression!!
             is PsiDeclarationStatement -> instruction.variable.initializer!!
+            is PsiField -> element.initializer!!
             else -> TODO("Not supported: ${element.javaClass}")
         }
         val mhType = typeData[expression] ?: resolveMhType(expression, block)

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
@@ -33,7 +33,7 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, private val typeData: Ty
 
     private fun onRead(instruction: ReadVariableInstruction, index: Int, block: Block) {
         if (isUnrelated(instruction.variable)) return
-        val value = ssaConstruction.readVariable(instruction.variable, block) ?: return
+        val value = ssaConstruction.readVariable(instruction.variable, block)
         if (value is Holder) {
             typeData[controlFlow.getElement(index)] = value.value
         } else if (value is Phi) {
@@ -41,6 +41,8 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, private val typeData: Ty
                 .flatMap { if (it is Holder) listOf(it.value) else resolvePhi(it as Phi) }
                 .reduce { acc, mhType -> acc.join(mhType) }
             typeData[controlFlow.getElement(index)] = type
+        } else {
+            typeData[controlFlow.getElement(index)] = typeData[instruction.variable] ?: return
         }
     }
 
@@ -188,9 +190,12 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, private val typeData: Ty
                 return lookup(expression, arguments, block)
             }
         } else if (expression is PsiReferenceExpression) {
-            val value = ssaConstruction.readVariable(expression.resolve() as PsiVariable, block)
+            val variable = expression.resolve() as PsiVariable
+            val value = ssaConstruction.readVariable(variable, block)
             if (value is Holder) {
                 return value.value
+            } else if (variable is PsiField) {
+                return typeData[variable] ?: noMatch()
             }
         }
         return noMatch()

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
@@ -190,7 +190,7 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, private val typeData: Ty
                 return lookup(expression, arguments, block)
             }
         } else if (expression is PsiReferenceExpression) {
-            val variable = expression.resolve() as PsiVariable
+            val variable = expression.resolve() as? PsiVariable ?: return noMatch()
             val value = ssaConstruction.readVariable(variable, block)
             if (value is Holder) {
                 return value.value


### PR DESCRIPTION
Final fields with initializers can be analyzed for MethodHandle types.
This currently requires some workarounds as IJ doesn't emit a write instruction for the field assignment.