### PR TITLE
feature: add inspection for void/primitive type restrictions

### DIFF
--- a/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
@@ -229,9 +229,9 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, private val typeData: Ty
 
             "findStatic" -> {
                 if (arguments.size != 3) return noMatch()
-                val (_, _, type) = arguments
+                val (refc, _, type) = arguments
                 val t = type.mhType(block) ?: return notConstant()
-                LookupHelper.findStatic(t)
+                LookupHelper.findStatic(refc, t)
             }
 
             "findStaticGetter" -> findAccessor(arguments, LookupHelper::findStaticGetter)

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleMergeInspection.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleMergeInspection.kt
@@ -5,7 +5,7 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.JavaElementVisitor
 import com.intellij.psi.PsiElementVisitor
-import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.PsiExpression
 import de.sirywell.methodhandleplugin.TypeData
 import de.sirywell.methodhandleplugin.mhtype.BoundTop
 
@@ -16,12 +16,12 @@ class MethodHandleMergeInspection : LocalInspectionTool() {
     }
 
     class Visitor(private val problemsHolder: ProblemsHolder) : JavaElementVisitor() {
-        override fun visitMethodCallExpression(expression: PsiMethodCallExpression) {
+        override fun visitExpression(expression: PsiExpression) {
             val typeData = TypeData.forFile(expression.containingFile)
             val type = typeData[expression] ?: return
             if (type is BoundTop && type.expression == expression) {
                 problemsHolder.registerProblem(
-                    expression,
+                    type.target ?: expression,
                     type.message,
                     ProblemHighlightType.GENERIC_ERROR_OR_WARNING
                 )

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/LookupHelper.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/LookupHelper.kt
@@ -43,7 +43,11 @@ object LookupHelper {
         return prependParameter(type, paramType)
     }
 
-    fun findStatic(mhType: MhType) = mhType
+    fun findStatic(refc: PsiExpression, mhType: MhType): MhType {
+        val referenceClass = refc.getConstantOfType<PsiType>() ?: return Bot
+        if (referenceClass is PsiPrimitiveType) return referenceTypeExpected(refc, referenceClass)
+        return mhType
+    }
 
     fun findStaticGetter(refc: PsiExpression, type: PsiExpression): MhType {
         val referenceClass = refc.getConstantOfType<PsiType>() ?: return Bot

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/LookupHelper.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/LookupHelper.kt
@@ -12,29 +12,31 @@ object LookupHelper {
 
     fun findConstructor(refc: PsiExpression, type: MhType): MhType {
         if (type !is MhSingleType) return type
-        // TODO inspection in type return type
+        if (type.returnType != PsiType.VOID) return unexpectedReturnType(type.returnType, PsiType.VOID)
         val referenceClass = refc.getConstantOfType<PsiType>() ?: return Bot
-        // TODO inspection on non-reference type
+        if (referenceClass == PsiType.VOID) return typeMustNotBe(refc, PsiType.VOID)
         return type.withSignature(type.signature.withReturnType(referenceClass))
     }
 
     fun findGetter(refc: PsiExpression, type: PsiExpression): MhType {
         val referenceClass = refc.getConstantOfType<PsiType>() ?: return Bot
-        // TODO inspection on non-reference type
+        if (referenceClass is PsiPrimitiveType) return referenceTypeExpected(refc, referenceClass)
         val returnType = type.getConstantOfType<PsiType>() ?: return Bot
-        // TODO non-void inspection
+        if (returnType == PsiType.VOID) return typeMustNotBe(type, PsiType.VOID)
         return MhExactType(MHS.create(returnType, listOf(referenceClass)))
     }
 
     fun findSetter(refc: PsiExpression, type: PsiExpression): MhType {
         val referenceClass = refc.getConstantOfType<PsiType>() ?: return Bot
-        // TODO inspection on non-reference type
+        if (referenceClass is PsiPrimitiveType) return referenceTypeExpected(refc, referenceClass)
         val paramType = type.getConstantOfType<PsiType>() ?: return Bot
-        // TODO non-void inspection
-        return MhExactType(MHS.create(PsiPrimitiveType.VOID, listOf(referenceClass, paramType)))
+        if (paramType == PsiType.VOID) return typeMustNotBe(type, PsiType.VOID)
+        return MhExactType(MHS.create(PsiType.VOID, listOf(referenceClass, paramType)))
     }
 
     fun findSpecial(refc: PsiExpression, type: MhType, specialCaller: PsiExpression): MhType {
+        val referenceClass = refc.getConstantOfType<PsiType>() ?: return Bot
+        if (referenceClass is PsiPrimitiveType) return referenceTypeExpected(refc, referenceClass)
         if (type !is MhSingleType) return type
         // TODO inspection:  caller class must be a subclass below the method
         val paramType = specialCaller.getConstantOfType<PsiType>() ?: return Bot
@@ -44,20 +46,24 @@ object LookupHelper {
     fun findStatic(mhType: MhType) = mhType
 
     fun findStaticGetter(refc: PsiExpression, type: PsiExpression): MhType {
-        // TODO inspection on non-reference type
+        val referenceClass = refc.getConstantOfType<PsiType>() ?: return Bot
+        if (referenceClass is PsiPrimitiveType) return referenceTypeExpected(refc, referenceClass)
         val returnType = type.getConstantOfType<PsiType>() ?: return Bot
-        // TODO non-void inspection
+        if (returnType == PsiType.VOID) return typeMustNotBe(type, PsiType.VOID)
         return MhExactType(MHS.create(returnType, listOf()))
     }
 
     fun findStaticSetter(refc: PsiExpression, type: PsiExpression): MhType {
-        // TODO inspection on non-reference type
+        val referenceClass = refc.getConstantOfType<PsiType>() ?: return Bot
+        if (referenceClass is PsiPrimitiveType) return referenceTypeExpected(refc, referenceClass)
         val paramType = type.getConstantOfType<PsiType>() ?: return Bot
-        // TODO non-void inspection
+        if (paramType == PsiType.VOID) return typeMustNotBe(type, PsiType.VOID)
         return MhExactType(MHS.create(PsiPrimitiveType.VOID, listOf(paramType)))
     }
 
     fun findVirtual(refc: PsiExpression, mhType: MhType): MhType {
+        val referenceClass = refc.getConstantOfType<PsiType>() ?: return Bot
+        if (referenceClass is PsiPrimitiveType) return referenceTypeExpected(refc, referenceClass)
         if (mhType !is MhSingleType) return mhType
         val paramType = refc.getConstantOfType<PsiType>() ?: return Bot
         // TODO not exactly correct, receiver could be restricted to lookup class

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/typeSupport.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/typeSupport.kt
@@ -1,0 +1,34 @@
+package de.sirywell.methodhandleplugin.mhtype
+
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiType
+import de.sirywell.methodhandleplugin.MethodHandleBundle
+
+fun typeMustNotBe(expression: PsiExpression, type: PsiType): MhType {
+    return Top.inspect(
+        MethodHandleBundle.message(
+            "problem.merging.general.typeMustNotBe",
+            type.presentableText
+        ),
+        expression
+    )
+}
+
+fun unexpectedReturnType(returnType: PsiType, expected: PsiType): MhType {
+    return Top.inspect(
+        MethodHandleBundle.message(
+            "problem.merging.general.otherReturnTypeExpected",
+            returnType.presentableText,
+            expected.presentableText
+        )
+    )
+}
+fun referenceTypeExpected(expression: PsiExpression, type: PsiType): MhType {
+    return Top.inspect(
+        MethodHandleBundle.message(
+            "problem.merging.general.referenceTypeExpected",
+            type.presentableText,
+        ),
+        expression
+    )
+}

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/types.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/types.kt
@@ -1,5 +1,6 @@
 package de.sirywell.methodhandleplugin.mhtype
 
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
 import de.sirywell.methodhandleplugin.MHS
 import de.sirywell.methodhandleplugin.MethodHandleSignature
@@ -102,11 +103,11 @@ sealed interface TopType : MhType {
     override fun join(other: MhType) = this
     override fun withSignature(signature: MethodHandleSignature) = this
 }
-data class InspectionTop(val message: String): TopType {
-    override fun at(expression: PsiExpression) = BoundTop(message, expression)
+data class UnboundTop(val message: String, val target: PsiElement?): TopType {
+    override fun at(expression: PsiExpression) = BoundTop(message, expression, target)
     override fun toString() = "Top(${message.take(5)})"
 }
-data class BoundTop(val message: String, val expression: PsiExpression): TopType {
+data class BoundTop(val message: String, val expression: PsiExpression, val target: PsiElement?): TopType {
     override fun at(expression: PsiExpression) = this
 
     override fun toString() = "Top(${message.take(5)})"
@@ -115,8 +116,8 @@ object Top: TopType {
     override fun at(expression: PsiExpression) = this
 
     override fun toString() = "Top"
-    fun inspect(message: @Nls String): MhType {
-        return InspectionTop(message)
+    fun inspect(message: @Nls String, target: PsiElement? = null): MhType {
+        return UnboundTop(message, target)
     }
 }
 object Bot : MhType {

--- a/src/main/resources/messages/MethodHandleMessages.properties
+++ b/src/main/resources/messages/MethodHandleMessages.properties
@@ -12,3 +12,6 @@ displayname.dataflow.analysis.methodhandle.merge=MethodHandle merge issues
 problem.creation.arguments.invalid.type=Parameter must not be of type {0}.
 problem.merging.catchException.missingException=Argument 'handler' is missing leading exception parameter {0} or supertype.
 problem.merging.general.incompatibleReturnType=Incompatible return types: {0} != {1}
+problem.merging.general.otherReturnTypeExpected=Unexpected return type {0}, must be {1}.
+problem.merging.general.referenceTypeExpected=Unexpected return type {0}, must be a reference type.
+problem.merging.general.typeMustNotBe=Type must not be {0}.


### PR DESCRIPTION
The `find*` methods in `MethodHandle.Lookup` require reference types as first argument, and the getter/setter methods additionally restrict the type of the field to non-void types.