### PR TITLE
fix: fix imprecise inspection for MethodHandles.constant

### DIFF
--- a/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleCreationInspection.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleCreationInspection.kt
@@ -30,18 +30,28 @@ class MethodHandleCreationInspection: LocalInspectionTool() {
             val parameters = expression.argumentList.expressionTypes
             if (parameters.size != 2) return
             // TODO this method does not match the actual behavior
-            if (!TypeConversionUtil.areTypesConvertible(type.signature.returnType, parameters[1])) {
+            if (!returnTypesAreCompatible(type, parameters[1])) {
                 // TODO fix message
                 problemsHolder.registerProblem(
                     expression.methodExpression as PsiExpression,
-                    MethodHandleBundle.message("problem.invocation.arguments.wrong.types",
-                        type.signature.parameters.map { it.presentableText },
-                        expression.argumentList.expressionTypes.map { it.presentableText }
+                    MethodHandleBundle.message("problem.creation.arguments.expected.type",
+                        type.signature.returnType.presentableText,
+                        parameters[1].presentableText
                     ),
                     ProblemHighlightType.GENERIC_ERROR_OR_WARNING
                 )
             }
             checkParamNotVoidAt(expression, 0)
+        }
+
+        private fun returnTypesAreCompatible(
+            type: MhExactType,
+            parameter: PsiType
+        ): Boolean {
+            if (type.signature.returnType is PsiPrimitiveType) {
+                return TypeConversionUtil.isAssignable(type.signature.returnType, parameter)
+            }
+            return TypeConversionUtil.areTypesConvertible(type.signature.returnType, parameter)
         }
 
         private fun checkParamNotVoidAt(expression: PsiMethodCallExpression, index: Int) {

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleCreationInspection.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleCreationInspection.kt
@@ -29,9 +29,7 @@ class MethodHandleCreationInspection: LocalInspectionTool() {
         private fun checkConstant(expression: PsiMethodCallExpression, type: MhExactType) {
             val parameters = expression.argumentList.expressionTypes
             if (parameters.size != 2) return
-            // TODO this method does not match the actual behavior
             if (!returnTypesAreCompatible(type, parameters[1])) {
-                // TODO fix message
                 problemsHolder.registerProblem(
                     expression.methodExpression as PsiExpression,
                     MethodHandleBundle.message("problem.creation.arguments.expected.type",

--- a/src/main/resources/messages/MethodHandleMessages.properties
+++ b/src/main/resources/messages/MethodHandleMessages.properties
@@ -10,6 +10,7 @@ problem.invocation.arguments.wrong.types=There are arguments with wrong static t
 displayname.dataflow.analysis.methodhandle.creation=MethodHandle creation issues
 displayname.dataflow.analysis.methodhandle.merge=MethodHandle merge issues
 problem.creation.arguments.invalid.type=Parameter must not be of type {0}.
+problem.creation.arguments.expected.type=Expected parameter of type {0} but got {1}.
 problem.merging.catchException.missingException=Argument 'handler' is missing leading exception parameter {0} or supertype.
 problem.merging.general.incompatibleReturnType=Incompatible return types: {0} != {1}
 problem.merging.general.otherReturnTypeExpected=Unexpected return type {0}, must be {1}.

--- a/src/test/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleInspectionsTest.kt
+++ b/src/test/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleInspectionsTest.kt
@@ -19,5 +19,6 @@ class MethodHandleInspectionsTest : LightJavaCodeInsightFixtureTestCase() {
 
     fun testVoidInIdentity() = doTest()
 
+    fun testWrongArgumentTypeInConstant() = doTest()
 
 }

--- a/src/test/testData/WrongArgumentTypeInConstant.java
+++ b/src/test/testData/WrongArgumentTypeInConstant.java
@@ -1,0 +1,13 @@
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+class WrongArgumentTypeInConstant {
+  private static final MethodHandle a = <warning descr="Expected parameter of type byte but got int.">MethodHandles.constant</warning>(byte.class, 0);
+  private static final MethodHandle b = <warning descr="Expected parameter of type int but got String.">MethodHandles.constant</warning>(int.class, "Hello World"); // CCE
+  private static final MethodHandle c = <warning descr="Expected parameter of type byte but got int.">MethodHandles.constant</warning>(byte.class, 0); // CCE
+  private static final MethodHandle d = MethodHandles.constant(byte.class, (byte) 0); // fine
+  private static final MethodHandle e = MethodHandles.constant(int.class, (byte) 0); // fine
+  private static final MethodHandle f = MethodHandles.constant(CharSequence.class, "Hello"); // fine
+  private static final MethodHandle g = MethodHandles.constant(String.class, (CharSequence) "a"); // fine
+  private static final MethodHandle h = <warning descr="Expected parameter of type String but got Integer.">MethodHandles.constant</warning>(String.class, Integer.valueOf(1)); // CCE
+}


### PR DESCRIPTION
The type compatibility check wasn't precise resulting and undetected problems. This PR addresses the shortcomings and also adds tests for it.