### PR TITLE
fix: emit warning on MethodHandles.constant(void.class, ...)

### DIFF
--- a/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleCreationInspection.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleCreationInspection.kt
@@ -46,10 +46,13 @@ class MethodHandleCreationInspection: LocalInspectionTool() {
             type: MhExactType,
             parameter: PsiType
         ): Boolean {
-            if (type.signature.returnType is PsiPrimitiveType) {
-                return TypeConversionUtil.isAssignable(type.signature.returnType, parameter)
+            val returnType = type.signature.returnType
+            // void.class in invalid in constant(...), so skip here and handle it later separately
+            if (returnType == PsiType.VOID) return true
+            if (returnType is PsiPrimitiveType) {
+                return TypeConversionUtil.isAssignable(returnType, parameter)
             }
-            return TypeConversionUtil.areTypesConvertible(type.signature.returnType, parameter)
+            return TypeConversionUtil.areTypesConvertible(returnType, parameter)
         }
 
         private fun checkParamNotVoidAt(expression: PsiMethodCallExpression, index: Int) {

--- a/src/test/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleInspectionsTest.kt
+++ b/src/test/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleInspectionsTest.kt
@@ -21,4 +21,6 @@ class MethodHandleInspectionsTest : LightJavaCodeInsightFixtureTestCase() {
 
     fun testWrongArgumentTypeInConstant() = doTest()
 
+    fun testVoidInConstant() = doTest()
+
 }

--- a/src/test/testData/VoidInConstant.java
+++ b/src/test/testData/VoidInConstant.java
@@ -1,0 +1,6 @@
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+class VoidInIdentity {
+  private static final MethodHandle A = MethodHandles.constant(<warning descr="Parameter must not be of type void.">void.class</warning>, null);
+}


### PR DESCRIPTION
Previously, a warning was generated for the second argument as it isn't type-compatible with void, but obviously it makes more sense to emit a warning for the disallowed usage of void.class as first parameter.