### PR TITLE
feature: introduce type-checking tests via custom inspection

### DIFF
--- a/src/test/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleInspectionsTest.kt
+++ b/src/test/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleInspectionsTest.kt
@@ -5,10 +5,14 @@ import de.sirywell.methodhandleplugin.inspection.MethodHandleCreationInspection
 
 class MethodHandleInspectionsTest : LightJavaCodeInsightFixtureTestCase() {
 
-    private fun doTest() {
-        projectDescriptor.sdk
+    private fun doInspectionTest() {
         myFixture.enableInspections(MethodHandleCreationInspection())
         myFixture.testHighlighting(true, false, true, getTestName(false) + ".java")
+    }
+
+    private fun doTypeCheckingTest() {
+        myFixture.enableInspections(MethodHandleTypeHelperInspection())
+        myFixture.testHighlighting(false, true, false, getTestName(false) + ".java")
     }
 
     override fun getProjectDescriptor() = JAVA_LATEST_WITH_LATEST_JDK
@@ -17,10 +21,12 @@ class MethodHandleInspectionsTest : LightJavaCodeInsightFixtureTestCase() {
         return "src/test/testData/"
     }
 
-    fun testVoidInIdentity() = doTest()
+    fun testVoidInIdentity() = doInspectionTest()
 
-    fun testWrongArgumentTypeInConstant() = doTest()
+    fun testWrongArgumentTypeInConstant() = doInspectionTest()
 
-    fun testVoidInConstant() = doTest()
+    fun testVoidInConstant() = doInspectionTest()
+
+    fun testSimpleIdentity() = doTypeCheckingTest()
 
 }

--- a/src/test/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleTypeHelperInspection.kt
+++ b/src/test/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleTypeHelperInspection.kt
@@ -1,0 +1,25 @@
+package de.sirywell.methodhandleplugin.mhtype
+
+import com.intellij.codeInspection.LocalInspectionTool
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.codeInspection.ProblemsHolder
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiElementVisitor
+import de.sirywell.methodhandleplugin.TypeData
+
+/**
+ * We (mis)use this inspection to add the type info as highlighting to the source code.
+ * This way, we can reuse existing test infrastructure that is meant to assert presence of inspection results.
+ * I'm aware this is a bit hacky, but it's just too simple to go a different route.
+ */
+class MethodHandleTypeHelperInspection : LocalInspectionTool() {
+
+    override fun buildVisitor(holder: ProblemsHolder, isOnTheFly: Boolean): PsiElementVisitor {
+        return object : PsiElementVisitor() {
+            override fun visitElement(element: PsiElement) {
+                val foundType = TypeData.forFile(element.containingFile)[element] ?: return
+                holder.registerProblem(element, foundType.toString(), ProblemHighlightType.INFORMATION)
+            }
+        }
+    }
+}

--- a/src/test/testData/SimpleIdentity.java
+++ b/src/test/testData/SimpleIdentity.java
@@ -1,0 +1,6 @@
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+
+class SimpleIdentity {
+  <info descr="(int)int">private static final MethodHandle A = <info descr="(int)int">MethodHandles.identity(int.class)</info>;</info>
+}


### PR DESCRIPTION
Fixes #33.

We just use an inspection for tests that highlights all elements with `MhType` present as problem with `ProblemHighlightType.INFORMATION`. This way, we can simply write the expected types into the source files directly, just as with the tests for our inspections.