### PR TITLE
fix: workaround incompatibilities with IJ 241 build

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 0.0.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233
-pluginUntilBuild = 233.*
+pluginUntilBuild = 241.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension
 platformType = IC

--- a/gradle.properties
+++ b/gradle.properties
@@ -29,8 +29,7 @@ kotlin.stdlib.default.dependency = false
 kotlin.code.style=official
 
 # Enable Gradle Configuration Cache -> https://docs.gradle.org/current/userguide/configuration_cache.html
-# TODO figure out configuration caching with test sdk download
-org.gradle.configuration-cache = false
+org.gradle.configuration-cache = true
 # Enable Gradle Build Cache -> https://docs.gradle.org/current/userguide/build_cache.html
 org.gradle.caching = true
 

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/psiSupport.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/psiSupport.kt
@@ -1,7 +1,11 @@
 package de.sirywell.methodhandleplugin
 
 import com.intellij.codeInspection.dataFlow.CommonDataflow
+import com.intellij.codeInspection.dataFlow.CommonDataflow.DataflowResult
 import com.intellij.psi.*
+import java.lang.invoke.MethodHandle
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType.methodType
 
 val PsiMethodCallExpression.methodName
     get() = this.methodExpression.referenceName
@@ -28,9 +32,29 @@ fun PsiDeclarationStatement.getVariable(): PsiVariable? {
     return element as? PsiVariable
 }
 
+// if only >=241 is supported, this can be simplified again
+@Suppress("UnstableApiUsage")
+val getDataflowResult: MethodHandle = run {
+    val lookup = MethodHandles.lookup()
+    val commonDataflowClass = CommonDataflow::class.java
+    try {
+        lookup.findStatic(
+            commonDataflowClass,
+            "getDataflowResult",
+            methodType(DataflowResult::class.java, PsiExpression::class.java)
+        )
+    } catch (_: Exception) {
+        lookup.findStatic(
+            commonDataflowClass,
+            "getDataflowResult",
+            methodType(DataflowResult::class.java, PsiElement::class.java)
+        )
+    }
+}
+
 @Suppress("UnstableApiUsage")
 inline fun <reified T> PsiExpression.getConstantOfType(): T? {
-    return CommonDataflow.getDataflowResult(this)
+    return (getDataflowResult(this) as DataflowResult?)
         ?.getDfType(this)
         ?.getConstantOfType(T::class.java)
 }


### PR DESCRIPTION
Make 241.* builds work and re-enable configuration cache (which was disabled due to the sdk downloading)