### PR TITLE
test: add test for MethodHandles#dropReturn

### DIFF
--- a/src/test/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleInspectionsTest.kt
+++ b/src/test/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleInspectionsTest.kt
@@ -65,6 +65,8 @@ class MethodHandleInspectionsTest : LightJavaCodeInsightFixtureTestCase() {
 
     fun testMethodHandlesDropArguments() = doTypeCheckingTest()
 
+    fun testMethodHandlesDropReturn() = doTypeCheckingTest()
+
     fun testMethodHandlesEmpty() = doTypeCheckingTest()
 
     fun testMethodHandlesIdentity() = doTypeCheckingTest()

--- a/src/test/testData/MethodHandlesDropReturn.java
+++ b/src/test/testData/MethodHandlesDropReturn.java
@@ -1,0 +1,11 @@
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+class MethodHandlesDropReturn {
+  static {
+    try {
+      <info descr="(int)void">MethodHandle mh = <info descr="(int)void">MethodHandles.dropReturn(<info descr="(int)int">MethodHandles.identity(int.class)</info>)</info>;</info>
+    } catch (Throwable ignored) {}
+  }
+}


### PR DESCRIPTION
After #71 we can now add tests for methods added after Java 11.