### PR TITLE
feature: allow more precise inspections during analysis

### DIFF
--- a/src/main/kotlin/de/sirywell/methodhandleplugin/TypeData.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/TypeData.kt
@@ -1,5 +1,6 @@
 package de.sirywell.methodhandleplugin
 
+import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.openapi.util.ModificationTracker
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiFile
@@ -21,9 +22,16 @@ class TypeData: ModificationTracker by ModificationTracker.NEVER_CHANGED {
         }
     }
     private val map = mutableMapOf<PsiElement, MhType>()
+    private val problems = mutableMapOf<PsiElement, (ProblemsHolder) -> Unit>()
 
     operator fun get(element: PsiElement) = map[element]
     operator fun set(element: PsiElement, type: MhType) {
         map[element] = type
     }
+
+    fun reportProblem(element: PsiElement, reporter: (ProblemsHolder) -> Unit) {
+        problems[element] = reporter
+    }
+
+    fun problemFor(element: PsiElement): ((ProblemsHolder) -> Unit)? = problems[element]
 }

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleMergeInspection.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleMergeInspection.kt
@@ -1,13 +1,12 @@
 package de.sirywell.methodhandleplugin.inspection
 
 import com.intellij.codeInspection.LocalInspectionTool
-import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.codeInspection.ProblemsHolder
 import com.intellij.psi.JavaElementVisitor
+import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
-import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiReferenceExpression
 import de.sirywell.methodhandleplugin.TypeData
-import de.sirywell.methodhandleplugin.mhtype.BoundTop
 
 class MethodHandleMergeInspection : LocalInspectionTool() {
 
@@ -16,16 +15,15 @@ class MethodHandleMergeInspection : LocalInspectionTool() {
     }
 
     class Visitor(private val problemsHolder: ProblemsHolder) : JavaElementVisitor() {
-        override fun visitExpression(expression: PsiExpression) {
-            val typeData = TypeData.forFile(expression.containingFile)
-            val type = typeData[expression] ?: return
-            if (type is BoundTop && type.expression == expression) {
-                problemsHolder.registerProblem(
-                    type.target ?: expression,
-                    type.message,
-                    ProblemHighlightType.GENERIC_ERROR_OR_WARNING
-                )
+        override fun visitElement(element: PsiElement) {
+            val reporter = TypeData.forFile(element.containingFile).problemFor(element)
+            if (reporter != null) {
+                reporter(problemsHolder)
             }
+        }
+
+        override fun visitReferenceExpression(expression: PsiReferenceExpression) {
+            visitElement(expression)
         }
 
     }

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleTransformer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleTransformer.kt
@@ -11,7 +11,7 @@ object MethodHandleTransformer {
     // fun asSpreader()
 
     // TODO this is not exactly right...
-    fun asType(type: MhType, newType: MhType) = MethodHandlesMerger.explicitCastArguments(type, newType)
+    fun asType(type: MhType, newType: MhType): MhType = TODO()
 
     // fun asVarargsCollector()
 

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/types.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/types.kt
@@ -1,7 +1,6 @@
 package de.sirywell.methodhandleplugin.mhtype
 
 import com.intellij.psi.PsiElement
-import com.intellij.psi.PsiExpression
 import de.sirywell.methodhandleplugin.MHS
 import de.sirywell.methodhandleplugin.MethodHandleSignature
 import de.sirywell.methodhandleplugin.MethodHandleSignature.Companion.create
@@ -18,7 +17,6 @@ import org.jetbrains.annotations.Nls
 sealed interface MhType {
     fun join(other: MhType): MhType
     fun withSignature(signature: MethodHandleSignature): MhType
-    fun at(expression: PsiExpression): MhType
 }
 
 sealed class MhSingleType(val signature: MethodHandleSignature) : MhType {
@@ -30,8 +28,6 @@ sealed class MhSingleType(val signature: MethodHandleSignature) : MhType {
     override fun toString(): String {
         return signature.toString()
     }
-
-    override fun at(expression: PsiExpression) = this
 }
 
 class MhExactType(signature: MethodHandleSignature) : MhSingleType(signature) {
@@ -104,16 +100,10 @@ sealed interface TopType : MhType {
     override fun withSignature(signature: MethodHandleSignature) = this
 }
 data class UnboundTop(val message: String, val target: PsiElement?): TopType {
-    override fun at(expression: PsiExpression) = BoundTop(message, expression, target)
     override fun toString() = "Top(${message.take(5)})"
 }
-data class BoundTop(val message: String, val expression: PsiExpression, val target: PsiElement?): TopType {
-    override fun at(expression: PsiExpression) = this
 
-    override fun toString() = "Top(${message.take(5)})"
-}
 object Top: TopType {
-    override fun at(expression: PsiExpression) = this
 
     override fun toString() = "Top"
     fun inspect(message: @Nls String, target: PsiElement? = null): MhType {
@@ -123,7 +113,6 @@ object Top: TopType {
 object Bot : MhType {
     override fun join(other: MhType) = other
     override fun withSignature(signature: MethodHandleSignature) = this
-    override fun at(expression: PsiExpression) = this
 
     override fun toString() = "Bottom"
 }

--- a/src/main/resources/messages/MethodHandleMessages.properties
+++ b/src/main/resources/messages/MethodHandleMessages.properties
@@ -16,4 +16,8 @@ problem.merging.general.incompatibleReturnType=Incompatible return types: {0} !=
 problem.merging.general.otherReturnTypeExpected=Unexpected return type {0}, must be {1}.
 problem.merging.general.referenceTypeExpected=Unexpected return type {0}, must be a reference type.
 problem.merging.general.typeMustNotBe=Type must not be {0}.
+problem.merging.general.effectivelyIdenticalParametersExpected=Method parameters must be effectively identical but was {0}, {1}.
+problem.merging.permute.invalidReorderIndex=Reorder index value {2} is out of bounds [{0}, {1}).
+problem.merging.permute.invalidReorderIndexType=Reorder index value points to type {0} but expects type {1}.
+problem.merging.permute.reorderLengthMismatch=Reorder array length ({0}) does not match parameter count of new type ({1}).
 problem.invocation.returnType.mustBeVoid=MethodHandle returns void but is called in a non-void context.


### PR DESCRIPTION
Instead of attaching problems to the type, we rather store them in a map that we can go through later. That simplifies the type system and makes it easier to annotate specific elements with problems.