### PR TITLE
feature: improve inspections for bindTo

### DIFF
--- a/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
@@ -30,6 +30,7 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, val typeData: TypeData) 
     private val ssaConstruction = SsaConstruction<MethodHandleType>(controlFlow)
     private val methodHandlesMerger = MethodHandlesMerger(this)
     private val methodHandlesInitializer = MethodHandlesInitializer(this)
+    private val methodHandleTransformer = MethodHandleTransformer(this)
     private val lookupHelper = LookupHelper(this)
 
     fun doTraversal() {
@@ -186,7 +187,7 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, val typeData: TypeData) 
                         val target = qualifier ?: return noMatch()
                         val objectType = arguments[0].type ?: return notConstant()
                         val type = target.mhTypeOrNoMatch(block) ?: return noMatch()
-                        MethodHandleTransformer.bindTo(type, objectType)
+                        methodHandleTransformer.bindTo(target, arguments[0], block)
                     }
 
                     "withVarargs" -> TODO()

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
@@ -185,8 +185,6 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, val typeData: TypeData) 
                     "bindTo" -> {
                         if (arguments.size != 1) return noMatch()
                         val target = qualifier ?: return noMatch()
-                        val objectType = arguments[0].type ?: return notConstant()
-                        val type = target.mhTypeOrNoMatch(block) ?: return noMatch()
                         methodHandleTransformer.bindTo(target, arguments[0], block)
                     }
 

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleCreationInspection.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleCreationInspection.kt
@@ -33,7 +33,7 @@ class MethodHandleCreationInspection: LocalInspectionTool() {
             if (!returnTypesAreCompatible(signature, parameters[1])) {
                 problemsHolder.registerProblem(
                     expression.methodExpression as PsiExpression,
-                    MethodHandleBundle.message("problem.creation.arguments.expected.type",
+                    MethodHandleBundle.message("problem.general.parameters.expected.type",
                         signature.returnType(),
                         parameters[1].presentableText
                     ),

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/LookupHelper.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/LookupHelper.kt
@@ -107,7 +107,7 @@ class LookupHelper(private val ssaAnalyzer: SsaAnalyzer) {
     private fun emitMustBeReferenceType(refc: PsiExpression, referenceClass: Type) {
         emitProblem(
             refc, MethodHandleBundle.message(
-                "problem.merging.general.referenceTypeExpected",
+                "problem.merging.general.referenceTypeExpectedReturn",
                 referenceClass,
             )
         )

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleTransformer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleTransformer.kt
@@ -1,12 +1,15 @@
 package de.sirywell.methodhandleplugin.mhtype
 
-import com.intellij.psi.PsiType
-import de.sirywell.methodhandleplugin.type.CompleteSignature
-import de.sirywell.methodhandleplugin.type.DirectType
-import de.sirywell.methodhandleplugin.type.MethodHandleType
-import de.sirywell.methodhandleplugin.type.TopSignature
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiExpression
+import de.sirywell.methodhandleplugin.MethodHandleBundle.message
+import de.sirywell.methodhandleplugin.dfa.SsaAnalyzer
+import de.sirywell.methodhandleplugin.dfa.SsaConstruction
+import de.sirywell.methodhandleplugin.type.*
+import org.jetbrains.annotations.Nls
 
-object MethodHandleTransformer {
+class MethodHandleTransformer(private val ssaAnalyzer: SsaAnalyzer) {
 
     // fun asCollector()
 
@@ -19,14 +22,36 @@ object MethodHandleTransformer {
 
     // fun asVarargsCollector()
 
-    fun bindTo(type: MethodHandleType, objectType: PsiType): MethodHandleType {
+    fun bindTo(typeExpr: PsiExpression, objectType: PsiExpression, block: SsaConstruction.Block): MethodHandleType {
+        val type = ssaAnalyzer.mhType(typeExpr, block) ?: MethodHandleType(BotSignature)
         if (type.signature !is CompleteSignature) return type
         val firstParamType = type.signature.parameterTypes.getOrElse(0) { return MethodHandleType(TopSignature) }
-        if (firstParamType is DirectType && !firstParamType.psiType.isConvertibleFrom(objectType)) {
-            return MethodHandleType(TopSignature)
+        if (firstParamType is DirectType) {
+            if (firstParamType.isPrimitive()) {
+                return emitProblem(
+                    typeExpr,
+                    message("problem.merging.general.referenceTypeExpectedParameter", 0, firstParamType)
+                )
+            } else if (objectType.type != null && !firstParamType.psiType.isConvertibleFrom(objectType.type!!)) {
+                return emitProblem(
+                    objectType,
+                    message(
+                        "problem.general.parameters.expected.type",
+                        firstParamType,
+                        objectType.type!!.presentableText
+                    )
+                )
+            }
         }
         return MethodHandleType(type.signature.withParameterTypes(type.signature.parameterTypes.drop(1)))
     }
 
     // fun withVarargs()
+
+    private fun emitProblem(element: PsiElement, message: @Nls String): MethodHandleType {
+        ssaAnalyzer.typeData.reportProblem(element) {
+            it.registerProblem(element, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
+        }
+        return MethodHandleType(TopSignature)
+    }
 }

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleTransformer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleTransformer.kt
@@ -25,7 +25,9 @@ class MethodHandleTransformer(private val ssaAnalyzer: SsaAnalyzer) {
     fun bindTo(typeExpr: PsiExpression, objectType: PsiExpression, block: SsaConstruction.Block): MethodHandleType {
         val type = ssaAnalyzer.mhType(typeExpr, block) ?: MethodHandleType(BotSignature)
         if (type.signature !is CompleteSignature) return type
-        val firstParamType = type.signature.parameterTypes.getOrElse(0) { return MethodHandleType(TopSignature) }
+        val firstParamType = type.signature.parameterTypes.getOrElse(0) {
+            return emitProblem(typeExpr, message("problem.general.parameters.noParameter"))
+        }
         if (firstParamType is DirectType) {
             if (firstParamType.isPrimitive()) {
                 return emitProblem(

--- a/src/main/resources/messages/MethodHandleMessages.properties
+++ b/src/main/resources/messages/MethodHandleMessages.properties
@@ -10,11 +10,12 @@ problem.invocation.arguments.wrong.types=There are arguments with wrong static t
 displayname.dataflow.analysis.methodhandle.creation=MethodHandle creation issues
 displayname.dataflow.analysis.methodhandle.merge=MethodHandle merge issues
 problem.creation.arguments.invalid.type=Parameter must not be of type {0}.
-problem.creation.arguments.expected.type=Expected parameter of type {0} but got {1}.
+problem.general.parameters.expected.type=Expected parameter of type {0} but got {1}.
 problem.merging.catchException.missingException=Argument 'handler' is missing leading exception parameter {0} or supertype.
 problem.merging.general.incompatibleReturnType=Incompatible return types: {0} != {1}
 problem.merging.general.otherReturnTypeExpected=Unexpected return type {0}, must be {1}.
-problem.merging.general.referenceTypeExpected=Unexpected return type {0}, must be a reference type.
+problem.merging.general.referenceTypeExpectedReturn=Unexpected return type {0}, must be a reference type.
+problem.merging.general.referenceTypeExpectedParameter=Parameter type at index {0} must be a reference type but is {1}.
 problem.merging.general.arrayTypeExpected=Unexpected return type {0}, must be an array type.
 problem.merging.general.typeMustNotBe=Type must not be {0}.
 problem.merging.general.effectivelyIdenticalParametersExpected=Method parameters must be effectively identical but was {0}, {1}.

--- a/src/main/resources/messages/MethodHandleMessages.properties
+++ b/src/main/resources/messages/MethodHandleMessages.properties
@@ -11,6 +11,7 @@ displayname.dataflow.analysis.methodhandle.creation=MethodHandle creation issues
 displayname.dataflow.analysis.methodhandle.merge=MethodHandle merge issues
 problem.creation.arguments.invalid.type=Parameter must not be of type {0}.
 problem.general.parameters.expected.type=Expected parameter of type {0} but got {1}.
+problem.general.parameters.noParameter=MethodHandle type does not have a parameter but requires at least one.
 problem.merging.catchException.missingException=Argument 'handler' is missing leading exception parameter {0} or supertype.
 problem.merging.general.incompatibleReturnType=Incompatible return types: {0} != {1}
 problem.merging.general.otherReturnTypeExpected=Unexpected return type {0}, must be {1}.


### PR DESCRIPTION
`MethodHandle#bindTo` has some restrictions that we can check: It requires at least one parameter, the first parameter has to be a reference type, and the type must be compatible with the type of the object passed to the method.

With this change, all those requirements are covered by inspections with proper descriptions.