### PR TITLE
feature: separate typing structure for parameters

### DIFF
--- a/src/main/kotlin/de/sirywell/methodhandleplugin/TriState.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/TriState.kt
@@ -1,0 +1,13 @@
+package de.sirywell.methodhandleplugin
+
+enum class TriState {
+    YES,
+    UNKNOWN,
+    NO
+}
+
+fun Boolean?.toTriState() = when (this) {
+    null -> TriState.UNKNOWN
+    true -> TriState.YES
+    false -> TriState.NO
+}

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
@@ -103,7 +103,7 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, val typeData: TypeData) 
                         if (arguments.size == 2 && arguments[1].type == methodTypeType(expression)) {
                             MethodTypeHelper.methodType(
                                 arguments[0],
-                                arguments[1].mhType(block) ?: return notConstant()
+                                arguments[1].mhType(block) ?: notConstant()
                             )
                         } else {
                             MethodTypeHelper.methodType(arguments)
@@ -120,20 +120,20 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, val typeData: TypeData) 
                     }
 
                     "insertParameterTypes" -> {
-                        val mhType = qualifier?.mhType(block) ?: return noMatch()
+                        val mhType = qualifier?.mhType(block) ?: notConstant()
                         if (arguments.isEmpty()) return noMatch()
                         MethodTypeHelper.insertParameterTypes(mhType, arguments[0], arguments.drop(1))
                     }
 
                     "changeParameterType" -> {
-                        val mhType = qualifier?.mhType(block) ?: return noMatch()
+                        val mhType = qualifier?.mhType(block) ?: notConstant()
                         if (arguments.size != 2) return noMatch()
                         val (num, type) = arguments
                         MethodTypeHelper.changeParameterType(mhType, num, type)
                     }
 
                     "changeReturnType" -> {
-                        val mhType = qualifier?.mhType(block) ?: return noMatch()
+                        val mhType = qualifier?.mhType(block) ?: notConstant()
                         if (arguments.size != 1) return noMatch()
                         val type = arguments[0]
                         MethodTypeHelper.changeReturnType(mhType, type)

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandlesInitializer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandlesInitializer.kt
@@ -79,18 +79,15 @@ class MethodHandlesInitializer(private val ssaAnalyzer: SsaAnalyzer) {
     }
 
     fun invoker(mhType: MethodHandleType, methodHandleType: PsiType): MethodHandleType {
-        if (mhType.signature !is CompleteSignature) return mhType
         val signature = mhType.signature
         val pt = signature.parameterList.addAllAt(0, CompleteParameterList(listOf(DirectType(methodHandleType))))
         return MethodHandleType(CompleteSignature(signature.returnType, pt))
     }
 
     fun spreadInvoker(type: MethodHandleType, leadingArgCount: Int, objectType: PsiType): MethodHandleType {
-        if (type.signature !is CompleteSignature) return type
         if (leadingArgCount < 0) return topType
         val signature = type.signature
-        if (signature.parameterList !is CompleteParameterList) return topType
-        val parameterList = signature.parameterList as CompleteParameterList
+        val parameterList = signature.parameterList as? CompleteParameterList ?: return topType
         if (leadingArgCount >= parameterList.size) return topType
         val keep = parameterList.parameterTypes.subList(0, leadingArgCount).toMutableList()
         keep.add(DirectType(objectType.createArrayType()))

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandlesInitializer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandlesInitializer.kt
@@ -22,7 +22,7 @@ class MethodHandlesInitializer(private val ssaAnalyzer: SsaAnalyzer) {
     fun arrayConstructor(arrayClass: PsiExpression): MethodHandleType {
         val arrayType = arrayClass.asArrayType()
 
-        return MethodHandleType(CompleteSignature(arrayType, listOf(intType)))
+        return MethodHandleType(complete(arrayType, listOf(intType)))
     }
 
     fun arrayElementGetter(arrayClass: PsiExpression): MethodHandleType {
@@ -32,7 +32,7 @@ class MethodHandlesInitializer(private val ssaAnalyzer: SsaAnalyzer) {
         } else {
             DirectType((arrayType.psiType as PsiArrayType).componentType)
         }
-        return MethodHandleType(CompleteSignature(componentType, listOf(arrayType, intType)))
+        return MethodHandleType(complete(componentType, listOf(arrayType, intType)))
     }
 
     fun arrayElementSetter(arrayClass: PsiExpression): MethodHandleType {
@@ -42,14 +42,14 @@ class MethodHandlesInitializer(private val ssaAnalyzer: SsaAnalyzer) {
         } else {
             DirectType((arrayType.psiType as PsiArrayType).componentType)
         }
-        return MethodHandleType(CompleteSignature(voidType, listOf(arrayType, intType, componentType)))
+        return MethodHandleType(complete(voidType, listOf(arrayType, intType, componentType)))
     }
 
     // arrayElementVarHandle() no VarHandle support
 
     fun arrayLength(arrayClass: PsiExpression): MethodHandleType {
         val arrayType = arrayClass.asArrayType()
-        return MethodHandleType(CompleteSignature(intType, listOf(arrayType)))
+        return MethodHandleType(complete(intType, listOf(arrayType)))
     }
 
     // byteArray/BufferViewVarHandle() no VarHandle support
@@ -63,7 +63,7 @@ class MethodHandlesInitializer(private val ssaAnalyzer: SsaAnalyzer) {
         if (!typesAreCompatible(type, valueType, valueExpr)) {
             return emitProblem(valueExpr, message("problem.general.parameters.expected.type", type, valueType))
         }
-        return MethodHandleType(CompleteSignature(type, listOf()))
+        return MethodHandleType(complete(type, listOf()))
     }
 
     fun empty(mhType: MethodHandleType): MethodHandleType = mhType
@@ -75,33 +75,34 @@ class MethodHandlesInitializer(private val ssaAnalyzer: SsaAnalyzer) {
         if (type == voidType) {
             return emitProblem(typeExpr, message("problem.merging.general.typeMustNotBe", voidType))
         }
-        return MethodHandleType(CompleteSignature(type, listOf(type)))
+        return MethodHandleType(complete(type, listOf(type)))
     }
 
     fun invoker(mhType: MethodHandleType, methodHandleType: PsiType): MethodHandleType {
         if (mhType.signature !is CompleteSignature) return mhType
         val signature = mhType.signature
-        val list = signature.parameterTypes.toMutableList()
-        list.add(0, DirectType(methodHandleType))
-        return MethodHandleType(CompleteSignature(signature.returnType(), list))
+        val pt = signature.parameterList.addAllAt(0, CompleteParameterList(listOf(DirectType(methodHandleType))))
+        return MethodHandleType(CompleteSignature(signature.returnType, pt))
     }
 
     fun spreadInvoker(type: MethodHandleType, leadingArgCount: Int, objectType: PsiType): MethodHandleType {
         if (type.signature !is CompleteSignature) return type
         if (leadingArgCount < 0) return topType
         val signature = type.signature
-        if (leadingArgCount >= signature.parameterTypes.size) return topType
-        val keep = signature.parameterTypes.subList(0, leadingArgCount).toMutableList()
+        if (signature.parameterList !is CompleteParameterList) return topType
+        val parameterList = signature.parameterList as CompleteParameterList
+        if (leadingArgCount >= parameterList.size) return topType
+        val keep = parameterList.parameterTypes.subList(0, leadingArgCount).toMutableList()
         keep.add(DirectType(objectType.createArrayType()))
-        return MethodHandleType(CompleteSignature(signature.returnType(), keep))
+        return MethodHandleType(complete(signature.returnType, keep))
     }
 
     fun throwException(returnTypeExpr: PsiExpression, exTypeExpr: PsiExpression): MethodHandleType {
-        return MethodHandleType(CompleteSignature(returnTypeExpr.asType(), listOf(exTypeExpr.asType())))
+        return MethodHandleType(complete(returnTypeExpr.asType(), listOf(exTypeExpr.asType())))
     }
 
     fun zero(type: Type): MethodHandleType {
-        return MethodHandleType(CompleteSignature(type, listOf()))
+        return MethodHandleType(complete(type, listOf()))
     }
 
     private fun PsiExpression.asArrayType(): Type {

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodTypeHelper.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodTypeHelper.kt
@@ -4,6 +4,7 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
 import com.intellij.psi.PsiPrimitiveType
 import com.intellij.psi.PsiType
+import de.sirywell.methodhandleplugin.TriState
 import de.sirywell.methodhandleplugin.asType
 import de.sirywell.methodhandleplugin.getConstantOfType
 import de.sirywell.methodhandleplugin.mapToTypes
@@ -11,25 +12,24 @@ import de.sirywell.methodhandleplugin.type.*
 import java.util.Collections.nCopies
 
 object MethodTypeHelper {
+    private val topType = MethodHandleType(TopSignature)
 
     fun appendParameterTypes(mhType: MethodHandleType, ptypesToInsert: List<PsiExpression>): MethodHandleType {
         if (mhType.signature !is CompleteSignature) return mhType
-        val additionalTypes = ptypesToInsert.mapToTypes()
         // TODO check types for void
-        val parameters = mhType.signature.parameterTypes
+        val additionalTypes = ptypesToInsert.mapToTypes()
         if (additionalTypes.isEmpty()) return mhType // no change
-        return withParameters(mhType, parameters + additionalTypes)
+        val parameters = mhType.signature.parameterList as? CompleteParameterList ?: return topType
+        return withParameters(mhType, parameters.addAllAt(parameters.size, CompleteParameterList(additionalTypes)))
     }
 
     fun changeParameterType(mhType: MethodHandleType, num: PsiExpression, nptype: PsiExpression): MethodHandleType {
         if (mhType.signature !is CompleteSignature) return mhType
         val type = nptype.asType() // TODO inspection on void
         val pos = num.getConstantOfType<Int>() ?: return MethodHandleType(BotSignature)
-        val parameters = mhType.signature.parameterTypes
-        if (pos < 0 || pos > parameters.size) return MethodHandleType(TopSignature) // TODO inspection
-        val mutable = parameters.toMutableList()
-        mutable[pos] = type
-        return withParameters(mhType, mutable)
+        val parameters = mhType.signature.parameterList
+        if (pos < 0 || parameters.sizeMatches { pos > it } == TriState.YES) return topType // TODO inspection
+        return withParameters(mhType, parameters.setAt(pos, type))
     }
 
     fun changeReturnType(mhType: MethodHandleType, nrtype: PsiExpression): MethodHandleType {
@@ -42,30 +42,25 @@ object MethodTypeHelper {
         if (mhType.signature !is CompleteSignature) return mhType
         val startIndex = start.getConstantOfType<Int>() ?: return MethodHandleType(BotSignature)
         val endIndex = end.getConstantOfType<Int>() ?: return MethodHandleType(BotSignature)
-        val parameters = mhType.signature.parameterTypes
-        if (invalidRange(
-                parameters.size,
-                startIndex,
-                endIndex
-            )
-        ) return MethodHandleType(TopSignature) // TODO inspection
-        val mutable = parameters.toMutableList()
-        mutable.subList(startIndex, endIndex).clear()
-        return withParameters(mhType, mutable)
+        val parameters = mhType.signature.parameterList
+        val size = parameters.sizeOrNull() ?: return topType
+        if (invalidRange(size, startIndex, endIndex)) return topType // TODO inspection
+        return withParameters(mhType, parameters.removeAt(startIndex, endIndex - startIndex))
     }
 
     fun erase(mhType: MethodHandleType, objectType: PsiExpression): MethodHandleType {
-        if (mhType.signature !is CompleteSignature) return mhType
-        val params = mhType.signature.parameterTypes.map { it.erase(objectType.manager, objectType.resolveScope) }
         val ret = mhType.signature.returnType.erase(objectType.manager, objectType.resolveScope)
-        return MethodHandleType(CompleteSignature(ret, params))
+        val parameterList = mhType.signature.parameterList as? CompleteParameterList
+            ?: return MethodHandleType(complete(ret, TopParameterList))
+        val params = parameterList.parameterTypes.map { it.erase(objectType.manager, objectType.resolveScope) }
+        return MethodHandleType(complete(ret, params))
     }
 
     fun generic(mhType: MethodHandleType, objectType: PsiType): MethodHandleType {
         if (mhType.signature !is CompleteSignature) return mhType
-        val size = mhType.signature.parameterTypes.size
+        val size = (mhType.signature.parameterList as? CompleteParameterList) ?.size ?: return topType
         val objType = DirectType(objectType)
-        return MethodHandleType(CompleteSignature(objType, nCopies(size, objType)))
+        return MethodHandleType(complete(objType, nCopies(size, objType)))
     }
 
     fun genericMethodType(objectArgCount: PsiExpression, finalArray: Boolean, objectType: PsiType): MethodHandleType {
@@ -75,7 +70,7 @@ object MethodTypeHelper {
         if (finalArray) {
             parameters = parameters + DirectType(objectType.createArrayType())
         }
-        return MethodHandleType(CompleteSignature(objType, parameters))
+        return MethodHandleType(complete(objType, parameters))
     }
 
     fun insertParameterTypes(
@@ -84,20 +79,19 @@ object MethodTypeHelper {
         ptypesToInsert: List<PsiExpression>
     ): MethodHandleType {
         if (mhType.signature !is CompleteSignature) return mhType
-        val psiTypes = ptypesToInsert.mapToTypes()
+        val types = ptypesToInsert.mapToTypes()
         // TODO check types for void
-        val parameters = mhType.signature.parameterTypes
+        val parameters = mhType.signature.parameterList
         val pos = num.getConstantOfType<Int>() ?: return MethodHandleType(BotSignature)
-        if (pos < 0 || pos > parameters.size) return MethodHandleType(TopSignature) // TODO inspection
-        if (psiTypes.isEmpty()) return mhType // no change
-        val mutable = parameters.toMutableList()
-        mutable.addAll(pos, psiTypes)
+        if (pos < 0 || parameters.sizeMatches { pos > it } == TriState.YES) return topType // TODO inspection
+        if (types.isEmpty()) return mhType // no change
+        val mutable = parameters.addAllAt(pos, CompleteParameterList(types))
         return withParameters(mhType, mutable)
     }
 
     private fun withParameters(
         mhType: MethodHandleType,
-        newParameters: List<Type>
+        newParameters: ParameterList
     ) = MethodHandleType(mhType.signature.withParameterTypes(newParameters))
 
     private fun invalidRange(parametersSize: Int, start: Int, end: Int): Boolean {
@@ -107,7 +101,7 @@ object MethodTypeHelper {
     fun methodType(args: List<PsiExpression>): MethodHandleType {
         val rtype = args[0].asType()
         val params = args.drop(1).map { it.asType() }
-        return MethodHandleType(CompleteSignature(rtype, params))
+        return MethodHandleType(complete(rtype, params))
     }
 
     fun methodType(rtype: PsiExpression, mhType: MethodHandleType): MethodHandleType {
@@ -123,8 +117,10 @@ object MethodTypeHelper {
     private fun mapTypes(mhType: MethodHandleType, map: (Type) -> Type): MethodHandleType {
         if (mhType.signature !is CompleteSignature) return mhType
         val ret = map(mhType.signature.returnType)
-        val params = mhType.signature.parameterTypes.map { map(it) }
-        return MethodHandleType(CompleteSignature(ret, params))
+        val parameterList = mhType.signature.parameterList as? CompleteParameterList
+            ?: return MethodHandleType(complete(ret, TopParameterList))
+        val params = parameterList.parameterTypes.map { map(it) }
+        return MethodHandleType(complete(ret, params))
     }
 
     private fun unwrap(type: Type): Type {

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/type/CompleteSignature.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/type/CompleteSignature.kt
@@ -8,6 +8,8 @@ sealed interface Signature {
 
     fun withParameterTypes(parameterTypes: List<Type>): Signature
 
+    fun parameterTypeAt(index: Int): Type
+
     fun returnType(): Type
 }
 
@@ -18,6 +20,8 @@ data object BotSignature : Signature {
 
     override fun withParameterTypes(parameterTypes: List<Type>) = this
 
+    override fun parameterTypeAt(index: Int) = BotType
+
     override fun returnType() = BotType
 }
 
@@ -27,6 +31,8 @@ data object TopSignature : Signature {
     override fun withReturnType(returnType: Type) = this
 
     override fun withParameterTypes(parameterTypes: List<Type>) = this
+
+    override fun parameterTypeAt(index: Int) = TopType
 
     override fun returnType() = TopType
 }
@@ -53,6 +59,10 @@ data class CompleteSignature(
 
     override fun withParameterTypes(parameterTypes: List<Type>): Signature {
         return CompleteSignature(returnType, parameterTypes)
+    }
+
+    override fun parameterTypeAt(index: Int): Type {
+        return parameterTypes.getOrElse(index) { TopType }
     }
 
     override fun returnType(): Type {

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/type/ParameterList.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/type/ParameterList.kt
@@ -1,0 +1,230 @@
+package de.sirywell.methodhandleplugin.type
+
+import de.sirywell.methodhandleplugin.TriState
+import de.sirywell.methodhandleplugin.toTriState
+import java.util.*
+import java.util.stream.Collectors
+
+sealed interface ParameterList {
+    /**
+     * Returns [TopType] if the index is out of known bounds.
+     * Returns [BotType] if no better type is known for that index.
+     */
+    fun parameterType(index: Int): Type
+    operator fun get(index: Int) = parameterType(index)
+
+    fun join(parameterList: ParameterList): ParameterList
+
+    fun hasSize(size: Int): TriState
+
+    fun dropFirst(n: Int): ParameterList
+
+    fun removeAt(index: Int): ParameterList = removeAt(index, 1)
+
+    fun removeAt(index: Int, n: Int): ParameterList
+
+    fun addAllAt(index: Int, parameterList: ParameterList): ParameterList
+
+    fun setAt(index: Int, type: Type): ParameterList
+
+    operator fun set(index: Int, type: Type) = setAt(index, type)
+
+    fun sizeMatches(predicate: (Int) -> Boolean): TriState
+
+    fun sizeOrNull(): Int?
+
+}
+
+data object BotParameterList : ParameterList {
+    override fun parameterType(index: Int) = BotType
+    override fun join(parameterList: ParameterList) = parameterList
+    override fun hasSize(size: Int) = TriState.UNKNOWN
+    override fun dropFirst(n: Int) = this
+    override fun removeAt(index: Int, n: Int) = this
+    override fun addAllAt(index: Int, parameterList: ParameterList): ParameterList {
+        return IncompleteParameterList(parameterList.toMap().mapKeys { it.key + index }.toSortedMap())
+    }
+
+    override fun setAt(index: Int, type: Type): ParameterList {
+        if (index < 0) return TopParameterList
+        return IncompleteParameterList(sortedMapOf(index to type))
+    }
+
+    override fun sizeMatches(predicate: (Int) -> Boolean) = TriState.UNKNOWN
+    override fun sizeOrNull() = null
+}
+
+data object TopParameterList : ParameterList {
+    override fun parameterType(index: Int) = TopType
+    override fun join(parameterList: ParameterList) = this
+    override fun hasSize(size: Int) = TriState.UNKNOWN
+    override fun dropFirst(n: Int) = this
+    override fun removeAt(index: Int, n: Int) = this
+    override fun addAllAt(index: Int, parameterList: ParameterList) = this
+    override fun setAt(index: Int, type: Type) = TopParameterList
+
+    override fun sizeMatches(predicate: (Int) -> Boolean) = TriState.UNKNOWN
+    override fun sizeOrNull() = null
+}
+
+data class CompleteParameterList(val parameterTypes: List<Type>) : ParameterList {
+    val size get() = parameterTypes.size
+    override fun parameterType(index: Int): Type {
+        return parameterTypes.getOrElse(index) { TopType }
+    }
+
+    override fun join(parameterList: ParameterList): ParameterList {
+        return when (parameterList) {
+            BotParameterList -> this
+            TopParameterList -> TopParameterList
+            is CompleteParameterList -> {
+                if (size != parameterList.size) {
+                    TopParameterList
+                } else {
+                    CompleteParameterList(parameterTypes.zip(parameterList.parameterTypes).map { (a, b) -> a.join(b) })
+                }
+            }
+
+            is IncompleteParameterList -> {
+                if (size < parameterList.knownParameterTypes.lastKey()) {
+                    // this list is definitely smaller than the other list, therefore incompatible
+                    TopParameterList
+                } else {
+                    // join the known types, keep the rest (others would be BotType anyway)
+                    val params = parameterTypes.toMutableList()
+                    parameterList.knownParameterTypes.forEach { (index, type) ->
+                        params[index] = params[index].join(type)
+                    }
+                    CompleteParameterList(params)
+                }
+            }
+        }
+    }
+
+    override fun hasSize(size: Int) = (this.size == size).toTriState()
+    override fun dropFirst(n: Int): ParameterList {
+        if (parameterTypes.size < n) return TopParameterList
+        return CompleteParameterList(parameterTypes.drop(n))
+    }
+
+    override fun removeAt(index: Int, n: Int): ParameterList {
+        if (index < 0 || index + n - 1 > size) return TopParameterList
+        val list = parameterTypes.toMutableList()
+        list.subList(index, index + n).clear()
+        return CompleteParameterList(list)
+    }
+
+    override fun addAllAt(index: Int, parameterList: ParameterList): ParameterList {
+        if (index > size) return TopParameterList
+        return when (parameterList) {
+            BotParameterList -> IncompleteParameterList(parameterTypes.subList(0, index).toIndexedMap())
+            TopParameterList -> TopParameterList
+            is CompleteParameterList -> {
+                val list = parameterTypes.toMutableList()
+                list.addAll(index, parameterList.parameterTypes)
+                CompleteParameterList(list)
+            }
+
+            is IncompleteParameterList -> {
+                val map = parameterTypes.toIndexedMap().subMap(0, index)
+                val append = parameterList.knownParameterTypes.mapKeys { it.key + index }
+                IncompleteParameterList((map + append).toSortedMap())
+            }
+        }
+    }
+
+    override fun setAt(index: Int, type: Type): ParameterList {
+        if (index < 0 || index > parameterTypes.size) return TopParameterList
+        val list = parameterTypes.toMutableList()
+        list[index] = type
+        return CompleteParameterList(list)
+    }
+
+    override fun sizeMatches(predicate: (Int) -> Boolean): TriState {
+        return predicate(size).toTriState()
+    }
+
+    override fun sizeOrNull() = size
+
+    override fun toString(): String {
+        return parameterTypes.joinToString(separator = ",", prefix = "(", postfix = ")")
+    }
+}
+
+data class IncompleteParameterList(val knownParameterTypes: SortedMap<Int, Type>) : ParameterList {
+    override fun parameterType(index: Int): Type {
+        return knownParameterTypes[index] ?: if (index < 0) TopType else BotType
+    }
+
+    override fun join(parameterList: ParameterList): ParameterList {
+        return when (parameterList) {
+            BotParameterList -> this
+            TopParameterList -> TopParameterList
+            is CompleteParameterList -> parameterList.join(this) // do not reimplement code here for no reason
+            is IncompleteParameterList -> {
+                val new = (knownParameterTypes.entries + (parameterList.knownParameterTypes.entries))
+                    .stream()
+                    .collect(Collectors.toMap({ it.key }, { it.value }, Type::join))
+                IncompleteParameterList(new.toSortedMap())
+            }
+        }
+    }
+
+    override fun hasSize(size: Int) = TriState.UNKNOWN
+
+    override fun dropFirst(n: Int): ParameterList {
+        val mutableMap = knownParameterTypes.toMutableMap()
+        (0..<n).forEach { mutableMap.remove(it) }
+        return IncompleteParameterList(mutableMap.mapKeys { it.key - n }.toSortedMap())
+    }
+
+    override fun removeAt(index: Int, n: Int): ParameterList {
+        val mutableMap = knownParameterTypes.toMutableMap()
+        (0..<n).forEach { mutableMap.remove(index + it) }
+        return IncompleteParameterList(mutableMap.mapKeys { if (it.key >= index + n) it.key - n else it.key }
+            .toSortedMap())
+    }
+
+    override fun addAllAt(index: Int, parameterList: ParameterList): ParameterList {
+        return when (parameterList) {
+            BotParameterList -> IncompleteParameterList(knownParameterTypes.subMap(0, index))
+            TopParameterList -> TopParameterList
+            is CompleteParameterList -> {
+                val parameterTypes = parameterList.parameterTypes
+                val moved = parameterTypes.toIndexedMap().mapKeys { it.key + index }
+                val shifted =
+                    knownParameterTypes.mapKeys { if (it.key >= index) it.key + parameterTypes.size else it.key }
+                IncompleteParameterList((moved + shifted).toSortedMap())
+            }
+
+            is IncompleteParameterList -> {
+                val map = knownParameterTypes.subMap(0, index)
+                val append = parameterList.knownParameterTypes.mapKeys { it.key + index }
+                IncompleteParameterList((map + append).toSortedMap())
+            }
+        }
+
+    }
+
+    override fun setAt(index: Int, type: Type): ParameterList {
+        if (index < 0) return TopParameterList
+        val map = knownParameterTypes.toMutableMap()
+        map[index] = type
+        return IncompleteParameterList(map.toSortedMap())
+    }
+
+    override fun sizeMatches(predicate: (Int) -> Boolean) = TriState.UNKNOWN
+    override fun sizeOrNull() = null
+}
+
+private fun ParameterList.toMap(): SortedMap<Int, Type> {
+    return when (this) {
+        BotParameterList -> emptySortedMap()
+        TopParameterList -> emptySortedMap()
+        is CompleteParameterList -> parameterTypes.toIndexedMap()
+        is IncompleteParameterList -> knownParameterTypes
+    }
+}
+
+private fun <E> List<E>.toIndexedMap() = this.mapIndexed { index, e -> index to e }.toMap().toSortedMap()
+private fun <K, V> emptySortedMap() = Collections.emptySortedMap<K, V>()

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/type/ParameterList.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/type/ParameterList.kt
@@ -52,6 +52,8 @@ data object BotParameterList : ParameterList {
 
     override fun sizeMatches(predicate: (Int) -> Boolean) = TriState.UNKNOWN
     override fun sizeOrNull() = null
+
+    override fun toString() = "[⊥]"
 }
 
 data object TopParameterList : ParameterList {
@@ -65,6 +67,8 @@ data object TopParameterList : ParameterList {
 
     override fun sizeMatches(predicate: (Int) -> Boolean) = TriState.UNKNOWN
     override fun sizeOrNull() = null
+
+    override fun toString() = "[⊤]"
 }
 
 data class CompleteParameterList(val parameterTypes: List<Type>) : ParameterList {
@@ -215,6 +219,12 @@ data class IncompleteParameterList(val knownParameterTypes: SortedMap<Int, Type>
 
     override fun sizeMatches(predicate: (Int) -> Boolean) = TriState.UNKNOWN
     override fun sizeOrNull() = null
+
+    override fun toString(): String {
+        return "(" +
+                (0..knownParameterTypes.lastKey()).map { parameterType(it) }.joinToString(separator = ",") +
+                ",???)"
+    }
 }
 
 private fun ParameterList.toMap(): SortedMap<Int, Type> {

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/type/Signature.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/type/Signature.kt
@@ -19,9 +19,9 @@ sealed interface Signature {
 data object BotSignature : Signature {
     override fun join(signature: Signature) = signature
 
-    override fun withReturnType(returnType: Type) = this
+    override fun withReturnType(returnType: Type) = CompleteSignature(returnType, parameterList)
 
-    override fun withParameterTypes(parameterTypes: ParameterList) = this
+    override fun withParameterTypes(parameterTypes: ParameterList) = CompleteSignature(returnType, parameterTypes)
 
     override fun parameterTypeAt(index: Int) = BotType
 

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/type/Type.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/type/Type.kt
@@ -4,7 +4,9 @@ import com.intellij.psi.PsiManager
 import com.intellij.psi.PsiPrimitiveType
 import com.intellij.psi.PsiType
 import com.intellij.psi.search.GlobalSearchScope
+import de.sirywell.methodhandleplugin.TriState
 import de.sirywell.methodhandleplugin.objectType
+import de.sirywell.methodhandleplugin.toTriState
 
 sealed interface Type {
 
@@ -15,6 +17,8 @@ sealed interface Type {
     // TODO this method is questionable, there might be a better approach
     fun canBe(psiType: PsiType): Boolean
 
+    fun match(psiType: PsiType): TriState
+
     fun isPrimitive() = false
 }
 
@@ -22,6 +26,7 @@ data object BotType : Type {
     override fun join(other: Type) = other
     override fun erase(manager: PsiManager, scope: GlobalSearchScope) = this
     override fun canBe(psiType: PsiType) = true
+    override fun match(psiType: PsiType) = TriState.UNKNOWN
 
     override fun toString(): String {
         return "⊥"
@@ -32,6 +37,7 @@ data object TopType : Type {
     override fun join(other: Type) = this
     override fun erase(manager: PsiManager, scope: GlobalSearchScope) = this
     override fun canBe(psiType: PsiType) = false
+    override fun match(psiType: PsiType) = TriState.UNKNOWN
 
     override fun toString(): String {
         return "⊤"
@@ -56,6 +62,7 @@ data class DirectType(val psiType: PsiType) : Type {
     }
 
     override fun canBe(psiType: PsiType) = this.psiType == psiType
+    override fun match(psiType: PsiType) = (this.psiType == psiType).toTriState()
 
     override fun isPrimitive(): Boolean {
         return psiType is PsiPrimitiveType

--- a/src/test/testData/MethodHandlesCollectArguments.java
+++ b/src/test/testData/MethodHandlesCollectArguments.java
@@ -5,13 +5,13 @@ import java.lang.invoke.MethodType;
 class MethodHandlesCollectArguments {
   static {
     try {
-      MethodHandle target = MethodHandles.lookup().findStatic(Object.class, "?", MethodType.methodType(void.class, String.class, float.class, Double.class));
+      MethodHandle target = MethodHandles.empty(MethodType.methodType(void.class, String.class, float.class, Double.class));
       // one in target results in many in adapter
-      MethodHandle oneToMany = MethodHandles.lookup().findStatic(Object.class, "?", MethodType.methodType(String.class, double.class, Float.class));
+      MethodHandle oneToMany = MethodHandles.empty(MethodType.methodType(String.class, double.class, Float.class));
       // one in target results in zero in adapter
-      MethodHandle oneToZero = MethodHandles.lookup().findStatic(Object.class, "?", MethodType.methodType(float.class));
+      MethodHandle oneToZero = MethodHandles.empty(MethodType.methodType(float.class));
       // zero in target results in many in adapter
-      MethodHandle zeroToMany = MethodHandles.lookup().findStatic(Object.class, "?", MethodType.methodType(void.class, Integer.class, char.class));
+      MethodHandle zeroToMany = MethodHandles.empty(MethodType.methodType(void.class, Integer.class, char.class));
       <caret>
       <info descr="(double,Float,float,Double)void">MethodHandle mh0 = <info descr="(double,Float,float,Double)void">MethodHandles.collectArguments(target, 0, oneToMany)</info>;</info>
       <info descr="(String,Double)void">MethodHandle mh1 = <info descr="(String,Double)void">MethodHandles.collectArguments(target, 1, oneToZero)</info>;</info>


### PR DESCRIPTION
Sometimes the information about parameters is limited, but the return type is known. To represent partial information, the parameter list needs a better structure to represent different kinds of information. 