### PR TITLE
feature: implement variadic method handles support

### DIFF
--- a/src/main/kotlin/de/sirywell/methodhandleplugin/TriState.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/TriState.kt
@@ -3,7 +3,12 @@ package de.sirywell.methodhandleplugin
 enum class TriState {
     YES,
     UNKNOWN,
-    NO
+    NO;
+
+    fun join(other: TriState): TriState {
+        if (this != other) return UNKNOWN
+        return this
+    }
 }
 
 fun Boolean?.toTriState() = when (this) {

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleInvokeInspection.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/inspection/MethodHandleInvokeInspection.kt
@@ -11,10 +11,7 @@ import com.intellij.psi.*
 import com.intellij.psi.util.childrenOfType
 import com.intellij.refactoring.introduceVariable.JavaIntroduceVariableHandlerBase
 import de.sirywell.intellij.ReplaceMethodCallFix
-import de.sirywell.methodhandleplugin.MethodHandleBundle
-import de.sirywell.methodhandleplugin.TypeData
-import de.sirywell.methodhandleplugin.methodName
-import de.sirywell.methodhandleplugin.receiverIsMethodHandle
+import de.sirywell.methodhandleplugin.*
 import de.sirywell.methodhandleplugin.type.*
 import java.lang.invoke.MethodHandle
 import java.lang.invoke.MethodHandles
@@ -35,10 +32,13 @@ class MethodHandleInvokeInspection : LocalInspectionTool() {
             val (returnType, parameters) = type.signature
             when (expression.methodName) {
                 "invoke" -> {
-                    checkArgumentsCount(parameters, expression)
+                    if (type.signature.varargs == TriState.NO) {
+                        checkArgumentsCount(parameters, expression)
+                    }
                 }
 
                 "invokeExact" -> {
+                    // varargs does not matter for invokeExact
                     checkArgumentsTypes(parameters, expression)
                     checkArgumentsCount(parameters, expression)
                     checkReturnType(returnType, expression)

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleTransformer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandleTransformer.kt
@@ -4,6 +4,7 @@ import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
 import de.sirywell.methodhandleplugin.MethodHandleBundle.message
+import de.sirywell.methodhandleplugin.TriState
 import de.sirywell.methodhandleplugin.dfa.SsaAnalyzer
 import de.sirywell.methodhandleplugin.dfa.SsaConstruction
 import de.sirywell.methodhandleplugin.type.*
@@ -13,7 +14,7 @@ class MethodHandleTransformer(private val ssaAnalyzer: SsaAnalyzer) {
 
     // fun asCollector()
 
-    fun asFixedArity(type: MethodHandleType) = type
+    fun asFixedArity(type: MethodHandleType) = MethodHandleType(type.signature.withVarargs(TriState.NO))
 
     // fun asSpreader()
 

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandlesInitializer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/mhtype/MethodHandlesInitializer.kt
@@ -81,7 +81,7 @@ class MethodHandlesInitializer(private val ssaAnalyzer: SsaAnalyzer) {
     fun invoker(mhType: MethodHandleType, methodHandleType: PsiType): MethodHandleType {
         val signature = mhType.signature
         val pt = signature.parameterList.addAllAt(0, CompleteParameterList(listOf(DirectType(methodHandleType))))
-        return MethodHandleType(CompleteSignature(signature.returnType, pt))
+        return MethodHandleType(complete(signature.returnType, pt))
     }
 
     fun spreadInvoker(type: MethodHandleType, leadingArgCount: Int, objectType: PsiType): MethodHandleType {


### PR DESCRIPTION
MethodHandles can be variadic, in which case `invoke` calls can have an arbitrary number of trailing arguments. We need to keep track of that. As combinator methods (e.g. from `MethodHandles`) make handles non-variadic automatically, the default is `NO`.