### PR TITLE
feature: implement support for varHandle(Exact)Invoker methods

### DIFF
--- a/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/dfa/SsaAnalyzer.kt
@@ -461,6 +461,17 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, val typeData: TypeData) 
                 methodHandlesMerger.tryFinally(arguments[0], arguments[1], block)
             }
 
+            "varHandleExactInvoker",
+            "varHandleInvoker" -> {
+                if (arguments.size != 2) return noMatch()
+                methodHandlesInitializer.varHandleInvoker(
+                    arguments[0],
+                    arguments[1],
+                    expression.methodName == "varHandleExactInvoker",
+                    block
+                )
+            }
+
             "zero" -> {
                 if (arguments.size != 1) return noMatch()
                 methodHandlesInitializer.zero(arguments[0].asType())

--- a/src/main/kotlin/de/sirywell/methodhandleplugin/varHandleSupport.kt
+++ b/src/main/kotlin/de/sirywell/methodhandleplugin/varHandleSupport.kt
@@ -1,0 +1,51 @@
+package de.sirywell.methodhandleplugin
+
+// see VarHandle.AccessType
+enum class AccessType {
+    GET,
+    SET,
+    COMPARE_AND_SET,
+    COMPARE_AND_EXCHANGE,
+    GET_AND_UPDATE
+}
+
+fun accessTypeForAccessModeName(name: String): AccessType? {
+    return when (name) {
+        "GET",
+        "GET_ACQUIRE",
+        "GET_OPAQUE",
+        "GET_VOLATILE" -> AccessType.GET
+
+        "SET",
+        "SET_RELEASE",
+        "SET_OPAQUE",
+        "SET_VOLATILE" -> AccessType.SET
+
+        "COMPARE_AND_SET",
+        "WEAK_COMPARE_AND_SET_PLAIN",
+        "WEAK_COMPARE_AND_SET",
+        "WEAK_COMPARE_AND_SET_ACQUIRE",
+        "WEAK_COMPARE_AND_SET_RELEASE" -> AccessType.COMPARE_AND_SET
+
+        "COMPARE_AND_EXCHANGE",
+        "COMPARE_AND_EXCHANGE_ACQUIRE",
+        "COMPARE_AND_EXCHANGE_RELEASE" -> AccessType.COMPARE_AND_EXCHANGE
+
+        "GET_AND_SET",
+        "GET_AND_SET_ACQUIRE",
+        "GET_AND_SET_RELEASE",
+        "GET_AND_ADD",
+        "GET_AND_ADD_ACQUIRE",
+        "GET_AND_ADD_RELEASE",
+        "GET_AND_BITWISE_OR",
+        "GET_AND_BITWISE_OR_RELEASE",
+        "GET_AND_BITWISE_OR_ACQUIRE",
+        "GET_AND_BITWISE_AND",
+        "GET_AND_BITWISE_AND_RELEASE",
+        "GET_AND_BITWISE_AND_ACQUIRE",
+        "GET_AND_BITWISE_XOR",
+        "GET_AND_BITWISE_XOR_RELEASE",
+        "GET_AND_BITWISE_XOR_ACQUIRE" -> AccessType.GET_AND_UPDATE
+        else -> null
+    }
+}

--- a/src/main/resources/messages/MethodHandleMessages.properties
+++ b/src/main/resources/messages/MethodHandleMessages.properties
@@ -12,6 +12,8 @@ displayname.dataflow.analysis.methodhandle.merge=MethodHandle merge issues
 problem.creation.arguments.invalid.type=Parameter must not be of type {0}.
 problem.general.parameters.expected.type=Expected parameter of type {0} but got {1}.
 problem.general.parameters.noParameter=MethodHandle type does not have a parameter but requires at least one.
+problem.general.returnType.notAllowedX=Return type {0} not allowed here.
+problem.general.returnType.requiredX=Return type must be {0}.
 problem.merging.catchException.missingException=Argument 'handler' is missing leading exception parameter {0} or supertype.
 problem.merging.general.incompatibleReturnType=Incompatible return types: {0} != {1}
 problem.merging.general.otherReturnTypeExpected=Unexpected return type {0}, must be {1}.

--- a/src/test/kotlin/de/sirywell/methodhandleplugin/mhtype/VarHandleSupportTest.kt
+++ b/src/test/kotlin/de/sirywell/methodhandleplugin/mhtype/VarHandleSupportTest.kt
@@ -1,0 +1,31 @@
+package de.sirywell.methodhandleplugin.mhtype
+
+import de.sirywell.methodhandleplugin.AccessType
+import de.sirywell.methodhandleplugin.accessTypeForAccessModeName
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Test
+import java.lang.invoke.MethodHandles
+import java.lang.invoke.MethodType
+import java.lang.invoke.VarHandle.AccessMode
+
+class VarHandleSupportTest {
+
+    @Test
+    fun accessTypeAllCovered() {
+        for (value in AccessMode.entries) {
+            assertNotNull(accessTypeForAccessModeName(value.name))
+        }
+    }
+
+    @Test
+    fun accessTypesHaveSameMethodType() {
+        val mh = MethodHandles.arrayElementVarHandle(IntArray::class.java)
+        val types = mutableMapOf<AccessType, MutableSet<MethodType>>()
+        for (value in AccessMode.entries) {
+            types.computeIfAbsent(accessTypeForAccessModeName(value.name) ?: continue) { mutableSetOf() }
+                .add(mh.accessModeType(value))
+        }
+        types.forEach { (at, methodTypes) -> assertEquals("$at: $methodTypes", 1, methodTypes.size) }
+    }
+}


### PR DESCRIPTION
Those two methods construct a method handle that behaves like reflectively using a VarHandle. We also can have some basic inspections for the exact invoker. More would be possible, but is out of scope of this PR.