### PR TITLE
refactor: introduce common supertype ProblemEmitter

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/dfa/SsaAnalyzer.kt
@@ -32,6 +32,7 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, val typeData: TypeData) 
     private val methodHandlesInitializer = MethodHandlesInitializer(this)
     private val methodHandleTransformer = MethodHandleTransformer(this)
     private val lookupHelper = LookupHelper(this)
+    private val methodTypeHelper = MethodTypeHelper(this)
 
     fun doTraversal() {
         ssaConstruction.traverse(::onRead, ::onWrite)
@@ -106,59 +107,59 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, val typeData: TypeData) 
                     "methodType" -> {
                         if (arguments.isEmpty()) return noMatch()
                         if (arguments.size == 2 && arguments[1].type == methodTypeType(expression)) {
-                            MethodTypeHelper.methodType(
+                            methodTypeHelper.methodType(
                                 arguments[0],
                                 arguments[1].mhType(block) ?: notConstant()
                             )
                         } else {
-                            MethodTypeHelper.methodType(arguments)
+                            methodTypeHelper.methodType(arguments)
                         }
                     }
 
-                    "unwrap" -> MethodTypeHelper.unwrap(qualifier?.mhType(block) ?: return noMatch())
-                    "wrap" -> MethodTypeHelper.wrap(expression, qualifier?.mhType(block) ?: return noMatch())
+                    "unwrap" -> methodTypeHelper.unwrap(qualifier?.mhType(block) ?: return noMatch())
+                    "wrap" -> methodTypeHelper.wrap(expression, qualifier?.mhType(block) ?: return noMatch())
                     "dropParameterTypes" -> {
                         val mhType = qualifier?.mhType(block) ?: return noMatch()
                         if (arguments.size != 2) return noMatch()
                         val (start, end) = arguments
-                        MethodTypeHelper.dropParameterTypes(mhType, start, end)
+                        methodTypeHelper.dropParameterTypes(mhType, start, end)
                     }
 
                     "insertParameterTypes" -> {
                         val mhType = qualifier?.mhType(block) ?: notConstant()
                         if (arguments.isEmpty()) return noMatch()
-                        MethodTypeHelper.insertParameterTypes(mhType, arguments[0], arguments.drop(1))
+                        methodTypeHelper.insertParameterTypes(mhType, arguments[0], arguments.drop(1))
                     }
 
                     "changeParameterType" -> {
                         val mhType = qualifier?.mhType(block) ?: notConstant()
                         if (arguments.size != 2) return noMatch()
                         val (num, type) = arguments
-                        MethodTypeHelper.changeParameterType(mhType, num, type)
+                        methodTypeHelper.changeParameterType(mhType, num, type)
                     }
 
                     "changeReturnType" -> {
                         val mhType = qualifier?.mhType(block) ?: notConstant()
                         if (arguments.size != 1) return noMatch()
                         val type = arguments[0]
-                        MethodTypeHelper.changeReturnType(mhType, type)
+                        methodTypeHelper.changeReturnType(mhType, type)
                     }
 
                     "appendParameterTypes" ->
-                        MethodTypeHelper.appendParameterTypes(qualifier?.mhType(block) ?: return noMatch(), arguments)
+                        methodTypeHelper.appendParameterTypes(qualifier?.mhType(block) ?: return noMatch(), arguments)
 
                     "erase" ->
-                        MethodTypeHelper.erase(qualifier?.mhType(block) ?: return noMatch(), expression)
+                        methodTypeHelper.erase(qualifier?.mhType(block) ?: return noMatch(), expression)
 
                     "generic" ->
-                        MethodTypeHelper.generic(qualifier?.mhType(block) ?: return noMatch(), objectType(expression))
+                        methodTypeHelper.generic(qualifier?.mhType(block) ?: return noMatch(), objectType(expression))
 
                     "genericMethodType" -> {
                         val size = arguments.size
                         if (size != 1 && arguments.size != 2) return noMatch()
                         val finalArray =
                             if (size == 1) false else arguments[1].getConstantOfType<Boolean>() ?: return notConstant()
-                        MethodTypeHelper.genericMethodType(arguments[0], finalArray, objectType(expression))
+                        methodTypeHelper.genericMethodType(arguments[0], finalArray, objectType(expression))
                     }
 
                     "fromMethodDescriptorString" -> notConstant() // not supported

--- a/src/main/kotlin/de/sirywell/handlehints/inspection/ProblemEmitter.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/inspection/ProblemEmitter.kt
@@ -1,0 +1,76 @@
+package de.sirywell.handlehints.inspection
+
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiTypes
+import de.sirywell.handlehints.MethodHandleBundle.message
+import de.sirywell.handlehints.TypeData
+import de.sirywell.handlehints.type.MethodHandleType
+import de.sirywell.handlehints.type.TopSignature
+import de.sirywell.handlehints.type.Type
+import org.jetbrains.annotations.Nls
+
+abstract class ProblemEmitter(private val typeData: TypeData) {
+
+    protected fun emitProblem(element: PsiElement, message: @Nls String): MethodHandleType {
+        typeData.reportProblem(element) {
+            it.registerProblem(element, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
+        }
+        return MethodHandleType(TopSignature)
+    }
+
+    protected fun emitMustNotBeVoid(typeExpr: PsiExpression) {
+        emitProblem(
+            typeExpr,
+            message("problem.merging.general.typeMustNotBe", PsiTypes.voidType().presentableText)
+        )
+    }
+
+    protected fun emitMustBeReferenceType(refc: PsiExpression, referenceClass: Type) {
+        emitProblem(
+            refc, message(
+                "problem.merging.general.referenceTypeExpectedReturn",
+                referenceClass,
+            )
+        )
+    }
+
+    protected fun emitMustBeArrayType(refc: PsiExpression, referenceClass: Type) {
+        emitProblem(
+            refc, message(
+                "problem.merging.general.arrayTypeExpected",
+                referenceClass,
+            )
+        )
+    }
+
+    protected fun emitIncompatibleReturnTypes(
+        element: PsiElement,
+        first: Type,
+        second: Type
+    ): MethodHandleType {
+        return emitProblem(
+            element, message(
+                "problem.merging.general.incompatibleReturnType",
+                first,
+                second
+            )
+        )
+    }
+
+    protected fun emitOutOfBounds(
+        size: Int?,
+        targetExpr: PsiExpression,
+        pos: Int,
+        exclusive: Boolean
+    ) = if (size != null) {
+        if (exclusive) {
+            emitProblem(targetExpr, message("problem.general.position.invalidIndexKnownBoundsExcl", pos, size))
+        } else {
+            emitProblem(targetExpr, message("problem.general.position.invalidIndexKnownBoundsIncl", pos, size))
+        }
+    } else {
+        emitProblem(targetExpr, message("problem.general.position.invalidIndex", pos))
+    }
+}

--- a/src/main/kotlin/de/sirywell/handlehints/mhtype/LookupHelper.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/mhtype/LookupHelper.kt
@@ -1,16 +1,17 @@
 package de.sirywell.handlehints.mhtype
 
-import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.psi.*
+import com.intellij.psi.PsiClass
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiMethod
+import com.intellij.psi.PsiTypes
 import com.intellij.psi.util.PsiTypesUtil
 import de.sirywell.handlehints.*
 import de.sirywell.handlehints.dfa.SsaAnalyzer
 import de.sirywell.handlehints.dfa.SsaConstruction
+import de.sirywell.handlehints.inspection.ProblemEmitter
 import de.sirywell.handlehints.type.*
-import de.sirywell.handlehints.type.TopType
-import org.jetbrains.annotations.Nls
 
-class LookupHelper(private val ssaAnalyzer: SsaAnalyzer) {
+class LookupHelper(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(ssaAnalyzer.typeData) {
 
     // MethodHandle factory methods
 
@@ -102,29 +103,6 @@ class LookupHelper(private val ssaAnalyzer: SsaAnalyzer) {
         }
         val pt = CompleteParameterList(listOf(paramType)).addAllAt(1, mhType.signature.parameterList)
         return MethodHandleType(mhType.signature.withParameterTypes(pt).withVarargs(mhType.signature.varargs))
-    }
-
-    private fun emitProblem(element: PsiElement, message: @Nls String): MethodHandleType {
-        ssaAnalyzer.typeData.reportProblem(element) {
-            it.registerProblem(element, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
-        }
-        return MethodHandleType(TopSignature)
-    }
-
-    private fun emitMustNotBeVoid(typeExpr: PsiExpression) {
-        emitProblem(
-            typeExpr,
-            MethodHandleBundle.message("problem.merging.general.typeMustNotBe", PsiTypes.voidType().presentableText)
-        )
-    }
-
-    private fun emitMustBeReferenceType(refc: PsiExpression, referenceClass: Type) {
-        emitProblem(
-            refc, MethodHandleBundle.message(
-                "problem.merging.general.referenceTypeExpectedReturn",
-                referenceClass,
-            )
-        )
     }
 
     private fun PsiExpression.asReferenceType(): Type {

--- a/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandleTransformer.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandleTransformer.kt
@@ -1,16 +1,14 @@
 package de.sirywell.handlehints.mhtype
 
-import com.intellij.codeInspection.ProblemHighlightType
-import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
 import de.sirywell.handlehints.MethodHandleBundle.message
 import de.sirywell.handlehints.TriState
 import de.sirywell.handlehints.dfa.SsaAnalyzer
 import de.sirywell.handlehints.dfa.SsaConstruction
+import de.sirywell.handlehints.inspection.ProblemEmitter
 import de.sirywell.handlehints.type.*
-import org.jetbrains.annotations.Nls
 
-class MethodHandleTransformer(private val ssaAnalyzer: SsaAnalyzer) {
+class MethodHandleTransformer(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(ssaAnalyzer.typeData) {
 
     // fun asCollector()
 
@@ -64,10 +62,4 @@ class MethodHandleTransformer(private val ssaAnalyzer: SsaAnalyzer) {
 
     // fun withVarargs()
 
-    private fun emitProblem(element: PsiElement, message: @Nls String): MethodHandleType {
-        ssaAnalyzer.typeData.reportProblem(element) {
-            it.registerProblem(element, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
-        }
-        return MethodHandleType(TopSignature)
-    }
 }

--- a/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandlesInitializer.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandlesInitializer.kt
@@ -1,14 +1,12 @@
 package de.sirywell.handlehints.mhtype
 
-import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.*
 import de.sirywell.handlehints.*
 import de.sirywell.handlehints.MethodHandleBundle.message
 import de.sirywell.handlehints.dfa.SsaAnalyzer
 import de.sirywell.handlehints.dfa.SsaConstruction
+import de.sirywell.handlehints.inspection.ProblemEmitter
 import de.sirywell.handlehints.type.*
-import de.sirywell.handlehints.type.TopType
-import org.jetbrains.annotations.Nls
 
 private const val VAR_HANDLE_FQN = "java.lang.invoke.VarHandle"
 
@@ -16,7 +14,7 @@ private const val VAR_HANDLE_FQN = "java.lang.invoke.VarHandle"
  * Contains methods from [java.lang.invoke.MethodHandles] that create
  * new [java.lang.invoke.MethodHandle]s.
  */
-class MethodHandlesInitializer(private val ssaAnalyzer: SsaAnalyzer) {
+class MethodHandlesInitializer(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(ssaAnalyzer.typeData) {
 
     private val topType = MethodHandleType(TopSignature)
 
@@ -110,23 +108,6 @@ class MethodHandlesInitializer(private val ssaAnalyzer: SsaAnalyzer) {
             return TopType
         }
         return referenceClass
-    }
-
-    private fun emitProblem(element: PsiElement, message: @Nls String): MethodHandleType {
-        ssaAnalyzer.typeData.reportProblem(element) {
-            it.registerProblem(element, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
-        }
-        return MethodHandleType(TopSignature)
-    }
-
-
-    private fun emitMustBeArrayType(refc: PsiExpression, referenceClass: Type) {
-        emitProblem(
-            refc, message(
-                "problem.merging.general.arrayTypeExpected",
-                referenceClass,
-            )
-        )
     }
 
     private fun typesAreCompatible(

--- a/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodTypeHelper.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodTypeHelper.kt
@@ -6,12 +6,14 @@ import com.intellij.psi.PsiPrimitiveType
 import com.intellij.psi.PsiType
 import de.sirywell.handlehints.TriState
 import de.sirywell.handlehints.asType
+import de.sirywell.handlehints.dfa.SsaAnalyzer
 import de.sirywell.handlehints.getConstantOfType
+import de.sirywell.handlehints.inspection.ProblemEmitter
 import de.sirywell.handlehints.mapToTypes
 import de.sirywell.handlehints.type.*
 import java.util.Collections.nCopies
 
-object MethodTypeHelper {
+class MethodTypeHelper(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(ssaAnalyzer.typeData) {
     private val topType = MethodHandleType(TopSignature)
 
     fun appendParameterTypes(mhType: MethodHandleType, ptypesToInsert: List<PsiExpression>): MethodHandleType {


### PR DESCRIPTION
The new superclass holds functions that were previously duplicated across the implementing classes. This will become even more important with more inspections.