### PR TITLE
feature: implement VarHandle type analysis support

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/MethodTypeInlayHintsCollector.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/MethodTypeInlayHintsCollector.kt
@@ -9,8 +9,7 @@ import com.intellij.psi.PsiParameterList
 import com.intellij.psi.PsiReferenceExpression
 import com.intellij.refactoring.suggested.endOffset
 import com.intellij.refactoring.suggested.startOffset
-import de.sirywell.handlehints.type.BotSignature
-import de.sirywell.handlehints.type.TopSignature
+import de.sirywell.handlehints.type.*
 
 class MethodTypeInlayHintsCollector : SharedBypassCollector {
 
@@ -33,7 +32,10 @@ class MethodTypeInlayHintsCollector : SharedBypassCollector {
         val typeData = TypeData.forFile(element.containingFile)
         val type = typeData[element] ?: return
         // don't print
-        if (type.signature is TopSignature || type.signature is BotSignature) {
+        if (type is MethodHandleType && (type.signature is TopSignature || type.signature is BotSignature)) {
+            return
+        }
+        if (type is TopVarHandleType || type is BotVarHandleType) {
             return
         }
         sink.addPresentation(InlineInlayPosition(pos, belongsToBefore), hasBackground = true) {

--- a/src/main/kotlin/de/sirywell/handlehints/TypeData.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/TypeData.kt
@@ -7,8 +7,9 @@ import com.intellij.psi.PsiFile
 import com.intellij.psi.util.CachedValuesManager
 import de.sirywell.handlehints.dfa.MhTypeProvider
 import de.sirywell.handlehints.type.MethodHandleType
+import de.sirywell.handlehints.type.TypeLatticeElement
 
-class TypeData: ModificationTracker by ModificationTracker.NEVER_CHANGED {
+class TypeData : ModificationTracker by ModificationTracker.NEVER_CHANGED {
     companion object {
         fun forFile(file: PsiFile): TypeData {
             return CachedValuesManager.getManager(file.project)
@@ -21,11 +22,13 @@ class TypeData: ModificationTracker by ModificationTracker.NEVER_CHANGED {
                 )
         }
     }
-    private val map = mutableMapOf<PsiElement, MethodHandleType>()
+
+    private val map = mutableMapOf<PsiElement, TypeLatticeElement<*>>()
     private val problems = mutableMapOf<PsiElement, (ProblemsHolder) -> Unit>()
 
+    inline operator fun <reified T : TypeLatticeElement<*>> invoke(element: PsiElement) = get(element) as? T
     operator fun get(element: PsiElement) = map[element]
-    operator fun set(element: PsiElement, type: MethodHandleType) {
+    operator fun set(element: PsiElement, type: TypeLatticeElement<*>) {
         map[element] = type
     }
 

--- a/src/main/kotlin/de/sirywell/handlehints/inspection/MethodHandleInvokeInspection.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/inspection/MethodHandleInvokeInspection.kt
@@ -27,7 +27,7 @@ class MethodHandleInvokeInspection : LocalInspectionTool() {
             if (!receiverIsMethodHandle(expression)) return
             val target = expression.methodExpression.qualifierExpression ?: return
             val typeData = TypeData.forFile(expression.containingFile)
-            val type = typeData[target] ?: return
+            val type = typeData[target] as? MethodHandleType ?: return
             if (type.signature !is CompleteSignature) return // ignore for now
             val (returnType, parameters) = type.signature
             when (expression.methodName) {

--- a/src/main/kotlin/de/sirywell/handlehints/mhtype/LookupHelper.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/mhtype/LookupHelper.kt
@@ -16,7 +16,7 @@ class LookupHelper(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(ssaAna
     // MethodHandle factory methods
 
     fun findConstructor(refc: PsiExpression, typeExpr: PsiExpression, block: SsaConstruction.Block): MethodHandleType {
-        val type = ssaAnalyzer.mhType(typeExpr, block) ?: return MethodHandleType(BotSignature)
+        val type = ssaAnalyzer.methodHandleType(typeExpr, block) ?: return MethodHandleType(BotSignature)
         if (!type.signature.returnType.canBe(PsiTypes.voidType())) {
             emitProblem(
                 typeExpr,

--- a/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandleTransformer.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandleTransformer.kt
@@ -22,7 +22,7 @@ class MethodHandleTransformer(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmi
     // fun asVarargsCollector()
 
     fun bindTo(typeExpr: PsiExpression, objectType: PsiExpression, block: SsaConstruction.Block): MethodHandleType {
-        val type = ssaAnalyzer.mhType(typeExpr, block) ?: MethodHandleType(BotSignature)
+        val type = ssaAnalyzer.methodHandleType(typeExpr, block) ?: MethodHandleType(BotSignature)
         if (type.signature !is CompleteSignature) return type
         val parameterTypes = type.signature.parameterList
         val firstParamType =

--- a/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandlesMerger.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandlesMerger.kt
@@ -27,8 +27,8 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         block: SsaConstruction.Block
     ): MethodHandleType {
         val exType = exTypeExpr.asType()
-        val target = ssaAnalyzer.mhType(targetExpr, block) ?: bottomType
-        val handler = ssaAnalyzer.mhType(handlerExpr, block) ?: bottomType
+        val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
+        val handler = ssaAnalyzer.methodHandleType(handlerExpr, block) ?: bottomType
         val handlerParameterTypes = handler.signature.parameterList
         if (handlerParameterTypes is CompleteParameterList && (handlerParameterTypes.size == 0
                     || (exType is ExactType && !handlerParameterTypes[0].canBe(exType.psiType)))
@@ -62,8 +62,8 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         filterExpr: PsiExpression,
         block: SsaConstruction.Block
     ): MethodHandleType {
-        val target = ssaAnalyzer.mhType(targetExpr, block) ?: return bottomType
-        val filter = ssaAnalyzer.mhType(filterExpr, block) ?: return bottomType
+        val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: return bottomType
+        val filter = ssaAnalyzer.methodHandleType(filterExpr, block) ?: return bottomType
         var parameters = target.signature.parameterList
         val pos = posExpr.nonNegativeInt() ?: return bottomType
         if (parameters is CompleteParameterList && pos >= parameters.size) {
@@ -94,9 +94,9 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         bodyExpr: PsiExpression,
         block: SsaConstruction.Block
     ): MethodHandleType {
-        var iterations = ssaAnalyzer.mhType(iterationsExpr, block) ?: bottomType
-        var init = ssaAnalyzer.mhType(initExpr, block)
-        val body = ssaAnalyzer.mhType(bodyExpr, block) ?: bottomType
+        var iterations = ssaAnalyzer.methodHandleType(iterationsExpr, block) ?: bottomType
+        var init = ssaAnalyzer.methodHandleType(initExpr, block)
+        val body = ssaAnalyzer.methodHandleType(bodyExpr, block) ?: bottomType
         if (iterations.signature is BotSignature) {
             // iterations and init have an effectively identical parameter list
             // so if one is missing, just use the other, but assert return type
@@ -167,8 +167,8 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         bodyExpr: PsiExpression,
         block: SsaConstruction.Block
     ): MethodHandleType {
-        val start = ssaAnalyzer.mhType(startExpr, block) ?: bottomType
-        val end = ssaAnalyzer.mhType(endExpr, block) ?: bottomType
+        val start = ssaAnalyzer.methodHandleType(startExpr, block) ?: bottomType
+        val end = ssaAnalyzer.methodHandleType(endExpr, block) ?: bottomType
         if (start.signature.returnType.join(end.signature.returnType) == TopType) {
             return emitIncompatibleReturnTypes(startExpr, start.signature.returnType, end.signature.returnType)
         }
@@ -190,9 +190,9 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         predExpr: PsiExpression,
         block: SsaConstruction.Block
     ): MethodHandleType {
-        val init = ssaAnalyzer.mhType(initExpr, block) ?: bottomType
-        val body = ssaAnalyzer.mhType(bodyExpr, block) ?: bottomType
-        val pred = ssaAnalyzer.mhType(predExpr, block) ?: bottomType
+        val init = ssaAnalyzer.methodHandleType(initExpr, block) ?: bottomType
+        val body = ssaAnalyzer.methodHandleType(bodyExpr, block) ?: bottomType
+        val pred = ssaAnalyzer.methodHandleType(predExpr, block) ?: bottomType
         if (!pred.signature.returnType.canBe(PsiTypes.booleanType())) {
             return topType
         }
@@ -223,7 +223,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         block: SsaConstruction.Block
     ): MethodHandleType {
         val types = valueTypes.mapToTypes()
-        val target = ssaAnalyzer.mhType(targetExpr, block) ?: bottomType
+        val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
         val signature = target.signature
         if (signature.parameterList.compareSize(pos) == PartialOrder.LT) {
             return emitOutOfBounds(signature.parameterList.sizeOrNull(), targetExpr, pos, false)
@@ -237,7 +237,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
     // fun dropCoordinates() no VarHandle support, preview
 
     fun dropReturn(targetExpr: PsiExpression, block: SsaConstruction.Block): MethodHandleType {
-        val target = ssaAnalyzer.mhType(targetExpr, block) ?: bottomType
+        val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
         if (target.signature is CompleteSignature) {
             return MethodHandleType(target.signature.withReturnType(ExactType.voidType))
         }
@@ -249,8 +249,8 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         newTypeExpr: PsiExpression,
         block: SsaConstruction.Block
     ): MethodHandleType {
-        val target = ssaAnalyzer.mhType(targetExpr, block) ?: bottomType
-        val newType = ssaAnalyzer.mhType(newTypeExpr, block) ?: bottomType
+        val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
+        val newType = ssaAnalyzer.methodHandleType(newTypeExpr, block) ?: bottomType
         // TODO proper handling of bottom/top
         val newTypeParameterList = newType.signature.parameterList
         if (newTypeParameterList !is CompleteParameterList) return newType // result param types unknown
@@ -292,8 +292,8 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         filterExpr: PsiExpression,
         block: SsaConstruction.Block
     ): MethodHandleType {
-        val target = ssaAnalyzer.mhType(targetExpr, block) ?: bottomType
-        val filter = ssaAnalyzer.mhType(filterExpr, block) ?: bottomType
+        val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
+        val filter = ssaAnalyzer.methodHandleType(filterExpr, block) ?: bottomType
         // TODO proper handling of bottom/top
         if (filter.signature !is CompleteSignature || filter.signature.parameterList.hasSize(1) == TriState.NO) {
             return topType
@@ -330,9 +330,9 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         fallbackExpr: PsiExpression,
         block: SsaConstruction.Block
     ): MethodHandleType {
-        val test = ssaAnalyzer.mhType(testExpr, block) ?: bottomType
-        val target = ssaAnalyzer.mhType(targetExpr, block) ?: bottomType
-        val fallback = ssaAnalyzer.mhType(fallbackExpr, block) ?: bottomType
+        val test = ssaAnalyzer.methodHandleType(testExpr, block) ?: bottomType
+        val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
+        val fallback = ssaAnalyzer.methodHandleType(fallbackExpr, block) ?: bottomType
         // TODO proper handling of bottom/top
         val testSignature = test.signature // (A...)boolean
         val targetSignature = target.signature // (A... B...)T
@@ -358,7 +358,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         valueTypes: List<PsiExpression>,
         block: SsaConstruction.Block
     ): MethodHandleType {
-        val target = ssaAnalyzer.mhType(targetExpr, block) ?: bottomType
+        val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
         val pos = posExpr.nonNegativeInt() ?: return topType
         val parameterList = target.signature.parameterList
         if (parameterList.compareSize(pos + valueTypes.size) == PartialOrder.LT) {
@@ -386,8 +386,8 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         reorder: List<PsiExpression>,
         block: SsaConstruction.Block
     ): MethodHandleType {
-        val target = ssaAnalyzer.mhType(targetExpr, block) ?: bottomType
-        val newType = ssaAnalyzer.mhType(newTypeExpr, block) ?: bottomType
+        val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
+        val newType = ssaAnalyzer.methodHandleType(newTypeExpr, block) ?: bottomType
         if (target.signature.returnType.join(newType.signature.returnType) == TopType) {
             return emitIncompatibleReturnTypes(targetExpr, target.signature.returnType, newType.signature.returnType)
         }
@@ -436,9 +436,9 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         if (targetsExprs.isEmpty()) {
             emitProblem(fallbackExpr.parent, message("problem.merging.tableSwitch.noCases"))
         }
-        val fallback = ssaAnalyzer.mhType(fallbackExpr, block) ?: bottomType
+        val fallback = ssaAnalyzer.methodHandleType(fallbackExpr, block) ?: bottomType
         var error = checkFirstParameter(fallback.signature.parameterList, fallbackExpr)
-        val targets = targetsExprs.map { ssaAnalyzer.mhType(it, block) ?: bottomType }
+        val targets = targetsExprs.map { ssaAnalyzer.methodHandleType(it, block) ?: bottomType }
         for ((index, target) in targets.withIndex()) {
             error = error or checkFirstParameter(target.signature.parameterList, targetsExprs[index])
         }
@@ -473,8 +473,8 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         cleanupExpr: PsiExpression,
         block: SsaConstruction.Block
     ): MethodHandleType {
-        val target = ssaAnalyzer.mhType(targetExpr, block) ?: bottomType
-        val cleanup = ssaAnalyzer.mhType(cleanupExpr, block) ?: bottomType
+        val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
+        val cleanup = ssaAnalyzer.methodHandleType(cleanupExpr, block) ?: bottomType
         if (target.signature is BotSignature || cleanup.signature is BotSignature) return bottomType
         val cleanupSignature = cleanup.signature
         val targetSignature = target.signature

--- a/src/main/kotlin/de/sirywell/handlehints/type/MethodHandleType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/MethodHandleType.kt
@@ -1,9 +1,13 @@
 package de.sirywell.handlehints.type
 
+import de.sirywell.handlehints.TriState
+
 @JvmRecord
-data class MethodHandleType(val signature: Signature) {
-    fun join(methodHandleType: MethodHandleType): MethodHandleType {
-        return MethodHandleType(signature.join(methodHandleType.signature))
+data class MethodHandleType(val signature: Signature) : TypeLatticeElement<MethodHandleType> {
+
+    override fun joinIdentical(other: MethodHandleType): Pair<MethodHandleType, TriState> {
+        val (sig, identical) = signature.joinIdentical(other.signature)
+        return MethodHandleType(sig) to identical
     }
 
     override fun toString(): String {

--- a/src/main/kotlin/de/sirywell/handlehints/type/Signature.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/Signature.kt
@@ -2,11 +2,8 @@ package de.sirywell.handlehints.type
 
 import de.sirywell.handlehints.TriState
 
-sealed interface Signature {
+sealed interface Signature : TypeLatticeElement<Signature> {
 
-    fun join(signature: Signature) = joinIdentical(signature).first
-
-    fun joinIdentical(signature: Signature): Pair<Signature, TriState>
 
     fun withReturnType(returnType: Type): Signature
 
@@ -25,7 +22,7 @@ sealed interface Signature {
 }
 
 data object BotSignature : Signature {
-    override fun joinIdentical(signature: Signature) = signature to TriState.UNKNOWN
+    override fun joinIdentical(other: Signature) = other to TriState.UNKNOWN
 
     override fun withReturnType(returnType: Type) = CompleteSignature(returnType, parameterList, TriState.NO)
 
@@ -44,7 +41,7 @@ data object BotSignature : Signature {
 }
 
 data object TopSignature : Signature {
-    override fun joinIdentical(signature: Signature) = this to TriState.UNKNOWN
+    override fun joinIdentical(other: Signature) = this to TriState.UNKNOWN
 
     override fun withReturnType(returnType: Type) = this
 
@@ -67,9 +64,9 @@ data class CompleteSignature(
     override val parameterList: ParameterList,
     override val varargs: TriState
 ) : Signature {
-    override fun joinIdentical(signature: Signature): Pair<Signature, TriState> {
-        val (ret, rIdentical) = returnType.joinIdentical(signature.returnType)
-        val (params, pIdentical) = parameterList.joinIdentical(signature.parameterList)
+    override fun joinIdentical(other: Signature): Pair<Signature, TriState> {
+        val (ret, rIdentical) = returnType.joinIdentical(other.returnType)
+        val (params, pIdentical) = parameterList.joinIdentical(other.parameterList)
         return CompleteSignature(ret, params, TriState.NO) to rIdentical.sharpenTowardsNo(pIdentical)
     }
 

--- a/src/main/kotlin/de/sirywell/handlehints/type/Type.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/Type.kt
@@ -9,11 +9,7 @@ import de.sirywell.handlehints.TriState
 import de.sirywell.handlehints.objectType
 import de.sirywell.handlehints.toTriState
 
-sealed interface Type {
-
-    fun join(other: Type) = joinIdentical(other).first
-
-    fun joinIdentical(other: Type): Pair<Type, TriState>
+sealed interface Type : TypeLatticeElement<Type> {
 
     fun erase(manager: PsiManager, scope: GlobalSearchScope): Type
 

--- a/src/main/kotlin/de/sirywell/handlehints/type/TypeLatticeElement.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/TypeLatticeElement.kt
@@ -1,0 +1,21 @@
+package de.sirywell.handlehints.type
+
+import de.sirywell.handlehints.TriState
+
+sealed interface TypeLatticeElement<LE: TypeLatticeElement<LE>> {
+    fun join(other: LE) = joinIdentical(other).first
+    fun joinIdentical(other: LE): Pair<LE, TriState>
+}
+
+sealed interface BotTypeLatticeElement<LE: TypeLatticeElement<LE>> : TypeLatticeElement<LE> {
+    override fun joinIdentical(other: LE): Pair<LE, TriState> {
+        return other to TriState.UNKNOWN
+    }
+}
+sealed interface TopTypeLatticeElement<LE: TypeLatticeElement<LE>> : TypeLatticeElement<LE> {
+    override fun joinIdentical(other: LE): Pair<LE, TriState> {
+        return self() to TriState.UNKNOWN
+    }
+
+    fun self(): LE
+}

--- a/src/main/kotlin/de/sirywell/handlehints/type/VarHandleType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/VarHandleType.kt
@@ -1,0 +1,43 @@
+package de.sirywell.handlehints.type
+
+import de.sirywell.handlehints.TriState
+
+interface VarHandleType : TypeLatticeElement<VarHandleType> {
+    val variableType: Type
+    val coordinateTypes: ParameterList
+}
+
+data object BotVarHandleType : VarHandleType, BotTypeLatticeElement<VarHandleType> {
+    override val variableType = BotType
+    override val coordinateTypes = BotParameterList
+}
+
+data object TopVarHandleType : VarHandleType, TopTypeLatticeElement<VarHandleType> {
+    override fun self() = this
+    override val variableType = TopType
+    override val coordinateTypes = TopParameterList
+}
+
+data class CompleteVarHandleType(
+    override val variableType: Type,
+    override val coordinateTypes: ParameterList
+) : VarHandleType {
+    override fun joinIdentical(other: VarHandleType): Pair<VarHandleType, TriState> {
+        val (vt, identicalVt) = variableType.joinIdentical(other.variableType)
+        val (ct, identicalCt) = coordinateTypes.joinIdentical(other.coordinateTypes)
+        val identical = identicalVt.sharpenTowardsNo(identicalCt)
+        if (vt == TopType && ct == TopParameterList) {
+            return TopVarHandleType to identical
+        }
+        if (vt == BotType && ct == BotParameterList) {
+            return BotVarHandleType to identical
+        }
+        return CompleteVarHandleType(vt, ct) to identical
+    }
+
+    override fun toString(): String {
+        return "$coordinateTypes($variableType)"
+    }
+
+}
+

--- a/src/test/kotlin/de/sirywell/handlehints/mhtype/MethodHandleInspectionsTest.kt
+++ b/src/test/kotlin/de/sirywell/handlehints/mhtype/MethodHandleInspectionsTest.kt
@@ -57,6 +57,8 @@ class MethodHandleInspectionsTest : LightJavaCodeInsightFixtureTestCase() {
 
     fun testMethodHandlesArrayElementSetter() = doTypeCheckingTest()
 
+    fun testMethodHandlesArrayElementVarHandle() = doTypeCheckingTest()
+
     fun testMethodHandlesArrayLength() = doTypeCheckingTest()
 
     fun testMethodHandlesCatchException() = doTypeCheckingTest()

--- a/src/test/testData/MethodHandlesArrayElementVarHandle.java
+++ b/src/test/testData/MethodHandlesArrayElementVarHandle.java
@@ -1,0 +1,14 @@
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+
+class MethodHandlesArrayElementVarHandle {
+  void m() {
+    // valid use
+    <info descr="(int[],int)(int)">VarHandle vh0 = <info descr="(int[],int)(int)">MethodHandles.arrayElementVarHandle(int[].class)</info>;</info>
+    // not an array type
+    <info descr="(⊤,int)(⊤)">VarHandle vh1 = <info descr="(⊤,int)(⊤)">MethodHandles.arrayElementVarHandle(int.class)</info>;</info>
+    // multiple dimensions
+    <info descr="(String[][][],int)(String[][])">VarHandle vh2 = <info descr="(String[][][],int)(String[][])">MethodHandles.arrayElementVarHandle(String[][][].class)</info>;</info>
+  }
+}


### PR DESCRIPTION
Fixes #4. This is only the very beginning, making the type system work with the new type and supporting the `arrayElementVarHandle` as a test case to showcase the functionality.