### PR TITLE
feature: support cross-method type analysis for final fields

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/MethodTypeInlayHintsCollector.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/MethodTypeInlayHintsCollector.kt
@@ -3,6 +3,7 @@ package de.sirywell.handlehints
 import com.intellij.codeInsight.hints.declarative.InlayTreeSink
 import com.intellij.codeInsight.hints.declarative.InlineInlayPosition
 import com.intellij.codeInsight.hints.declarative.SharedBypassCollector
+import com.intellij.psi.PsiAssignmentExpression
 import com.intellij.psi.PsiDeclarationStatement
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiParameterList
@@ -18,6 +19,7 @@ class MethodTypeInlayHintsCollector : SharedBypassCollector {
             is PsiDeclarationStatement -> (element.getVariable()?.nameIdentifier?.endOffset
                 ?: element.endOffset) to true
 
+            is PsiAssignmentExpression -> (element.lExpression.endOffset) to true
             is PsiReferenceExpression -> {
                 // TODO ????
                 if (element.parent is PsiParameterList) {

--- a/src/test/kotlin/de/sirywell/handlehints/mhtype/MethodHandleInspectionsTest.kt
+++ b/src/test/kotlin/de/sirywell/handlehints/mhtype/MethodHandleInspectionsTest.kt
@@ -35,6 +35,8 @@ class MethodHandleInspectionsTest : LightJavaCodeInsightFixtureTestCase() {
 
     fun testVoidInConstant() = doInspectionTest()
 
+    fun testFinalFields() = doTypeCheckingTest()
+
     fun testLookupFindConstructor() = doTypeCheckingTest()
 
     fun testLookupFindGetter() = doTypeCheckingTest()

--- a/src/test/testData/FinalFields.java
+++ b/src/test/testData/FinalFields.java
@@ -27,12 +27,12 @@ public class FinalFields {
         <info descr="(CharSequence)int">this.methodType = <info descr="(CharSequence)int">MethodType.methodType(int.class, CharSequence.class)</info></info>;
         <info descr="(CharSequence)int">MethodHandle mn = <info descr="(CharSequence)int">MethodHandles.empty(this.methodType)</info>;</info>
         <info descr="(CharSequence)int">MethodHandle mni = <info descr="(CharSequence)int">MethodHandles.empty(methodType)</info>;</info>
-        <info descr="BotSignature">MethodHandle o = <info descr="BotSignature">MethodHandles.empty(other.methodType)</info>;</info>
+        <info descr="BotMethodHandleType">MethodHandle o = <info descr="BotMethodHandleType">MethodHandles.empty(other.methodType)</info>;</info>
         if (Math.random() < 0.5) {
             other = this;
-            <info descr="BotSignature">MethodHandle oy = <info descr="BotSignature">MethodHandles.empty(other.methodType)</info>;</info>
+            <info descr="BotMethodHandleType">MethodHandle oy = <info descr="BotMethodHandleType">MethodHandles.empty(other.methodType)</info>;</info>
         }
-        <info descr="BotSignature">MethodHandle om = <info descr="BotSignature">MethodHandles.empty(other.methodType)</info>;</info>
+        <info descr="BotMethodHandleType">MethodHandle om = <info descr="BotMethodHandleType">MethodHandles.empty(other.methodType)</info>;</info>
     }
 
     void m() {

--- a/src/test/testData/FinalFields.java
+++ b/src/test/testData/FinalFields.java
@@ -1,0 +1,43 @@
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class FinalFields {
+
+    <info descr="(double)⊤">private static final MethodType METHOD_TYPE;</info>
+
+    static {
+        if (Math.random() > 0.5) {
+            <info descr="(double)int">METHOD_TYPE = <info descr="(double)int">MethodType.methodType(int.class, double.class)</info></info>;
+            <info descr="(double)int">MethodHandle ms = <info descr="(double)int">MethodHandles.empty(METHOD_TYPE)</info>;</info>
+        } else {
+            <info descr="(double)float">METHOD_TYPE = <info descr="(double)float">MethodType.methodType(float.class, double.class)</info></info>;
+            <info descr="(double)float">MethodHandle ms = <info descr="(double)float">MethodHandles.empty(FinalFields.METHOD_TYPE)</info>;</info>
+        }
+        <info descr="(double)⊤">MethodHandle ms = <info descr="(double)⊤">MethodHandles.empty(METHOD_TYPE)</info>;</info>
+    }
+
+    <info descr="(⊤)int">private final MethodType methodType;</info>
+
+    FinalFields() {
+        <info descr="(String)int">this.methodType = <info descr="(String)int">MethodType.methodType(int.class, String.class)</info></info>;
+        <info descr="(String)int">MethodHandle mn = <info descr="(String)int">MethodHandles.empty(this.methodType)</info>;</info>
+    }
+    FinalFields(FinalFields other) {
+        <info descr="(CharSequence)int">this.methodType = <info descr="(CharSequence)int">MethodType.methodType(int.class, CharSequence.class)</info></info>;
+        <info descr="(CharSequence)int">MethodHandle mn = <info descr="(CharSequence)int">MethodHandles.empty(this.methodType)</info>;</info>
+        <info descr="(CharSequence)int">MethodHandle mni = <info descr="(CharSequence)int">MethodHandles.empty(methodType)</info>;</info>
+        <info descr="BotSignature">MethodHandle o = <info descr="BotSignature">MethodHandles.empty(other.methodType)</info>;</info>
+        if (Math.random() < 0.5) {
+            other = this;
+            <info descr="BotSignature">MethodHandle oy = <info descr="BotSignature">MethodHandles.empty(other.methodType)</info>;</info>
+        }
+        <info descr="BotSignature">MethodHandle om = <info descr="BotSignature">MethodHandles.empty(other.methodType)</info>;</info>
+    }
+
+    void m() {
+        <info descr="(double)⊤">MethodHandle ms = <info descr="(double)⊤">MethodHandles.empty(METHOD_TYPE)</info>;</info>
+
+        <info descr="(⊤)int">MethodHandle mn = <info descr="(⊤)int">MethodHandles.empty(this.methodType)</info>;</info>
+    }
+}


### PR DESCRIPTION
Storing `MethodType`s and `MethodHandle`s in final fields is common. Due to complexity, the assignment is often separate from the declaration. This makes analysis somewhat more complex, but we can join all assignments to a final field to determine its type. For instance fields, we also need to make sure that reading from a variable considers whether we read from `this` instance or a different one.