### PR TITLE
fix: initial types that can hold any value should be top

### DIFF
--- a/src/test/kotlin/de/sirywell/handlehints/mhtype/MethodHandleInspectionsTest.kt
+++ b/src/test/kotlin/de/sirywell/handlehints/mhtype/MethodHandleInspectionsTest.kt
@@ -37,6 +37,8 @@ class MethodHandleInspectionsTest : LightJavaCodeInsightFixtureTestCase() {
 
     fun testFinalFields() = doTypeCheckingTest()
 
+    fun testInitialTypes() = doTypeCheckingTest()
+
     fun testLookupFindConstructor() = doTypeCheckingTest()
 
     fun testLookupFindGetter() = doTypeCheckingTest()

--- a/src/test/testData/FinalFields.java
+++ b/src/test/testData/FinalFields.java
@@ -27,12 +27,12 @@ public class FinalFields {
         <info descr="(CharSequence)int">this.methodType = <info descr="(CharSequence)int">MethodType.methodType(int.class, CharSequence.class)</info></info>;
         <info descr="(CharSequence)int">MethodHandle mn = <info descr="(CharSequence)int">MethodHandles.empty(this.methodType)</info>;</info>
         <info descr="(CharSequence)int">MethodHandle mni = <info descr="(CharSequence)int">MethodHandles.empty(methodType)</info>;</info>
-        <info descr="BotMethodHandleType">MethodHandle o = <info descr="BotMethodHandleType">MethodHandles.empty(other.methodType)</info>;</info>
+        <info descr="TopMethodHandleType">MethodHandle o = <info descr="TopMethodHandleType">MethodHandles.empty(other.methodType)</info>;</info>
         if (Math.random() < 0.5) {
             other = this;
-            <info descr="BotMethodHandleType">MethodHandle oy = <info descr="BotMethodHandleType">MethodHandles.empty(other.methodType)</info>;</info>
+            <info descr="TopMethodHandleType">MethodHandle oy = <info descr="TopMethodHandleType">MethodHandles.empty(other.methodType)</info>;</info>
         }
-        <info descr="BotMethodHandleType">MethodHandle om = <info descr="BotMethodHandleType">MethodHandles.empty(other.methodType)</info>;</info>
+        <info descr="TopMethodHandleType">MethodHandle om = <info descr="TopMethodHandleType">MethodHandles.empty(other.methodType)</info>;</info>
     }
 
     void m() {

--- a/src/test/testData/InitialTypes.java
+++ b/src/test/testData/InitialTypes.java
@@ -1,0 +1,29 @@
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+public class InitialTypes {
+
+    void m(MethodType mt, boolean b, Inner inner) {
+        MethodHandle mh0;
+        if (b) {
+            <info descr="TopMethodHandleType">mh0 = <info descr="TopMethodHandleType">MethodHandles.empty(mt)</info></info>;
+        } else {
+            <info descr="()int">mh0 = <info descr="()int">MethodHandles.zero(int.class)</info></info>;
+        }
+        <info descr="TopMethodHandleType">MethodHandle mh1 = <info descr="TopMethodHandleType">myMethodHandleMethod()</info>;</info>
+        <info descr="TopMethodHandleType">MethodHandle mh2 = inner.methodHandle;</info>
+        <info descr="TopMethodHandleType">MethodHandle mh3 = create().methodHandle;</info>
+    }
+
+    private MethodHandle myMethodHandleMethod() {
+        return MethodHandles.zero(Object.class);
+    }
+
+    private Inner create() {
+        return new Inner();
+    }
+    static class Inner {
+        MethodHandle methodHandle;
+    }
+}


### PR DESCRIPTION
Unknown methods that return a type relevant for us, or parameters, or field accesses should considered a top type as they could hold any value.