### PR TITLE
feature: initial design of ValueLayout types

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/dfa/SsaAnalyzer.kt
@@ -123,6 +123,34 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, val typeData: TypeData) 
         return type != methodTypeType(context)
                 && type != methodHandleType(context)
                 && type != varHandleType(context)
+                && type !in memoryLayoutTypes(context)
+    }
+
+    private fun memoryLayoutTypes(context: PsiElement): Set<PsiType> {
+        // use a cache here
+        return object {
+            // https://docs.oracle.com/en/java/javase/22/docs/api/java.base/java/lang/foreign/MemoryLayout-sealed-graph.svg
+            val memoryLayoutTypes = listOf(
+                "java.lang.foreign.MemoryLayout",
+                "java.lang.foreign.SequenceLayout",
+                "java.lang.foreign.GroupLayout",
+                "java.lang.foreign.StructLayout",
+                "java.lang.foreign.UnionLayout",
+                "java.lang.foreign.PaddingLayout",
+                "java.lang.foreign.ValueLayout",
+                "java.lang.foreign.ValueLayout.OfBoolean",
+                "java.lang.foreign.ValueLayout.OfByte",
+                "java.lang.foreign.ValueLayout.OfChar",
+                "java.lang.foreign.ValueLayout.OfShort",
+                "java.lang.foreign.ValueLayout.OfInt",
+                "java.lang.foreign.ValueLayout.OfFloat",
+                "java.lang.foreign.ValueLayout.OfLong",
+                "java.lang.foreign.ValueLayout.OfDouble",
+                "java.lang.foreign.AddressLayout",
+            )
+                .map { PsiType.getTypeByName(it, context.project, context.resolveScope) }
+                .toSet()
+        }.memoryLayoutTypes
     }
 
     fun resolveType(expression: PsiExpression, block: Block): TypeLatticeElement<*>? {

--- a/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
@@ -5,6 +5,7 @@ import com.intellij.codeInspection.dataFlow.CommonDataflow.DataflowResult
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.resolve.reference.impl.JavaReflectionReferenceUtil
 import com.intellij.psi.search.GlobalSearchScope
+import com.intellij.psi.util.PsiTypesUtil
 import de.sirywell.handlehints.type.*
 import java.lang.invoke.MethodHandle
 import java.lang.invoke.MethodHandles
@@ -28,6 +29,12 @@ fun receiverIsMethodHandles(element: PsiMethodCallExpression) =
 fun receiverIsMethodType(element: PsiMethodCallExpression) = receiverIsInvokeClass(element, "MethodType")
 
 fun receiverIsLookup(element: PsiMethodCallExpression) = receiverIsInvokeClass(element, "MethodHandles.Lookup")
+
+fun receiverIsMemoryLayout(element: PsiMethodCallExpression): Boolean {
+    val superType = PsiType.getTypeByName("java.lang.foreign.MemoryLayout", element.project, element.resolveScope)
+    val actual = PsiTypesUtil.getClassType(element.resolveMethod()?.containingClass ?: return false)
+    return superType.isAssignableFrom(actual)
+}
 
 fun PsiDeclarationStatement.getVariable(): PsiVariable? {
     if (this.declaredElements.isEmpty()) return null

--- a/src/main/kotlin/de/sirywell/handlehints/type/MemoryLayoutType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/MemoryLayoutType.kt
@@ -1,0 +1,39 @@
+package de.sirywell.handlehints.type
+
+import de.sirywell.handlehints.TriState
+import de.sirywell.handlehints.toTriState
+
+interface MemoryLayoutType : TypeLatticeElement<MemoryLayoutType> {
+}
+
+data object BotMemoryLayoutType : MemoryLayoutType {
+    override fun joinIdentical(other: MemoryLayoutType) = other to TriState.UNKNOWN
+
+    override fun toString(): String {
+        return "⊥"
+    }
+}
+
+data object TopMemoryLayoutType : MemoryLayoutType {
+    override fun joinIdentical(other: MemoryLayoutType) = this to TriState.UNKNOWN
+
+    override fun toString(): String {
+        return "⊤"
+    }
+}
+
+data class ValueLayoutType(val type: Type, val byteAlignment: Int?) : MemoryLayoutType {
+    override fun joinIdentical(other: MemoryLayoutType): Pair<MemoryLayoutType, TriState> {
+        if (other is ValueLayoutType) {
+            val (new, identical) = this.type.joinIdentical(other.type)
+            val identicalAlignment = (byteAlignment?.equals(other.byteAlignment)).toTriState()
+            return ValueLayoutType(
+                new,
+                if (identicalAlignment == TriState.YES) byteAlignment else null
+            ) to identical.sharpenTowardsNo(identicalAlignment)
+        } else if (other is BotMemoryLayoutType) {
+            return this to TriState.UNKNOWN
+        }
+        return TopMemoryLayoutType to TriState.UNKNOWN
+    }
+}

--- a/src/main/kotlin/de/sirywell/handlehints/type/MemoryLayoutType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/MemoryLayoutType.kt
@@ -1,12 +1,18 @@
 package de.sirywell.handlehints.type
 
+import com.intellij.psi.PsiTypes
 import de.sirywell.handlehints.TriState
 import de.sirywell.handlehints.toTriState
 
-interface MemoryLayoutType : TypeLatticeElement<MemoryLayoutType> {
+sealed interface MemoryLayoutType : TypeLatticeElement<MemoryLayoutType> {
+    val byteSize: Int?
+    val byteAlignment: Int?
 }
 
 data object BotMemoryLayoutType : MemoryLayoutType, BotTypeLatticeElement<MemoryLayoutType> {
+    override val byteSize = null
+    override val byteAlignment = null
+
     override fun toString(): String {
         return "⊥"
     }
@@ -15,23 +21,40 @@ data object BotMemoryLayoutType : MemoryLayoutType, BotTypeLatticeElement<Memory
 data object TopMemoryLayoutType : MemoryLayoutType, TopTypeLatticeElement<MemoryLayoutType> {
     override fun self() = this
 
+    override val byteSize = null
+    override val byteAlignment = null
+
     override fun toString(): String {
         return "⊤"
     }
 }
 
-data class ValueLayoutType(val type: Type, val byteAlignment: Int?) : MemoryLayoutType {
+val ADDRESS_TYPE = ExactType(PsiTypes.nullType())
+
+data class ValueLayoutType(
+    val type: Type,
+    override val byteAlignment: Int?,
+    override val byteSize: Int?
+) : MemoryLayoutType {
     override fun joinIdentical(other: MemoryLayoutType): Pair<MemoryLayoutType, TriState> {
         if (other is ValueLayoutType) {
             val (new, identical) = this.type.joinIdentical(other.type)
-            val identicalAlignment = (byteAlignment?.equals(other.byteAlignment)).toTriState()
+            val identicalAlignment = (this.byteAlignment?.equals(other.byteAlignment)).toTriState()
+            val identicalSize = (this.byteSize?.equals(other.byteSize)).toTriState()
             return ValueLayoutType(
                 new,
-                if (identicalAlignment == TriState.YES) byteAlignment else null
-            ) to identical.sharpenTowardsNo(identicalAlignment)
+                if (identicalAlignment == TriState.YES) this.byteAlignment else null,
+                if (identicalSize == TriState.YES) this.byteSize else null
+            ) to identical.sharpenTowardsNo(identicalAlignment).sharpenTowardsNo(identicalSize)
         } else if (other is BotMemoryLayoutType) {
             return this to TriState.UNKNOWN
         }
         return TopMemoryLayoutType to TriState.UNKNOWN
+    }
+
+    override fun toString(): String {
+        return (if (byteAlignment != null) "$byteAlignment%" else "") +
+                "$type" +
+                if (byteSize != null) "$byteSize" else ""
     }
 }

--- a/src/main/kotlin/de/sirywell/handlehints/type/MemoryLayoutType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/MemoryLayoutType.kt
@@ -6,16 +6,14 @@ import de.sirywell.handlehints.toTriState
 interface MemoryLayoutType : TypeLatticeElement<MemoryLayoutType> {
 }
 
-data object BotMemoryLayoutType : MemoryLayoutType {
-    override fun joinIdentical(other: MemoryLayoutType) = other to TriState.UNKNOWN
-
+data object BotMemoryLayoutType : MemoryLayoutType, BotTypeLatticeElement<MemoryLayoutType> {
     override fun toString(): String {
         return "⊥"
     }
 }
 
-data object TopMemoryLayoutType : MemoryLayoutType {
-    override fun joinIdentical(other: MemoryLayoutType) = this to TriState.UNKNOWN
+data object TopMemoryLayoutType : MemoryLayoutType, TopTypeLatticeElement<MemoryLayoutType> {
+    override fun self() = this
 
     override fun toString(): String {
         return "⊤"

--- a/src/main/kotlin/de/sirywell/handlehints/type/Type.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/Type.kt
@@ -48,6 +48,20 @@ data class ExactType(val psiType: PsiType) : Type {
         val voidType = ExactType(PsiTypes.voidType())
         @JvmStatic
         val intType = ExactType(PsiTypes.intType())
+        @JvmStatic
+        val booleanType = ExactType(PsiTypes.booleanType())
+        @JvmStatic
+        val byteType = ExactType(PsiTypes.byteType())
+        @JvmStatic
+        val charType = ExactType(PsiTypes.charType())
+        @JvmStatic
+        val doubleType = ExactType(PsiTypes.doubleType())
+        @JvmStatic
+        val floatType = ExactType(PsiTypes.floatType())
+        @JvmStatic
+        val longType = ExactType(PsiTypes.longType())
+        @JvmStatic
+        val shortType = ExactType(PsiTypes.shortType())
     }
 
     override fun joinIdentical(other: Type): Pair<Type, TriState> {


### PR DESCRIPTION
The `java.lang.invoke` api is closely related to the `java.lang.foreign` API. Therefore, we should be able to model the latter to better support the former. For starters, we can now represent `ValueLayout` types.