### PR TITLE
feature: provide types as documentation

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/inspection/MethodHandleInvokeInspection.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/inspection/MethodHandleInvokeInspection.kt
@@ -48,7 +48,7 @@ class MethodHandleInvokeInspection : LocalInspectionTool() {
 
         private fun checkArgumentsTypes(parameters: TypeList, expression: PsiMethodCallExpression) {
             if (parameters !is CompleteTypeList) return
-            if (expression.argumentList.expressionTypes.zip(parameters.parameterTypes)
+            if (expression.argumentList.expressionTypes.zip(parameters.typeList)
                     .any { !it.second.canBe(it.first) }
             ) {
                 problemsHolder.registerProblem(

--- a/src/main/kotlin/de/sirywell/handlehints/mhtype/LookupHelper.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/mhtype/LookupHelper.kt
@@ -94,7 +94,7 @@ class LookupHelper(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(ssaAna
         mhType: MethodHandleType,
         paramType: Type
     ): MethodHandleType {
-        val pt = CompleteTypeList(listOf(paramType)).addAllAt(1, mhType.typeLatticeElementList)
+        val pt = CompleteTypeList(listOf(paramType)).addAllAt(1, mhType.parameterTypes)
         return mhType.withParameterTypes(pt).withVarargs(mhType.varargs)
     }
 

--- a/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandleTransformer.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandleTransformer.kt
@@ -24,7 +24,7 @@ class MethodHandleTransformer(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmi
     fun bindTo(typeExpr: PsiExpression, objectType: PsiExpression, block: SsaConstruction.Block): MethodHandleType {
         val type = ssaAnalyzer.methodHandleType(typeExpr, block) ?: BotMethodHandleType
         if (type !is CompleteMethodHandleType) return type
-        val parameterTypes = type.typeLatticeElementList
+        val parameterTypes = type.parameterTypes
         val firstParamType =
             // try to extract a first param if it exists
             // - CompleteParameterList has a first param if the size is > 0

--- a/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandlesInitializer.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandlesInitializer.kt
@@ -80,15 +80,15 @@ class MethodHandlesInitializer(private val ssaAnalyzer: SsaAnalyzer) : ProblemEm
     }
 
     fun invoker(mhType: MethodHandleType, methodHandleType: PsiType): MethodHandleType {
-        val pt = mhType.typeLatticeElementList.addAllAt(0, CompleteTypeList(listOf(ExactType(methodHandleType))))
+        val pt = mhType.parameterTypes.addAllAt(0, CompleteTypeList(listOf(ExactType(methodHandleType))))
         return complete(mhType.returnType, pt)
     }
 
     fun spreadInvoker(type: MethodHandleType, leadingArgCount: Int, objectType: PsiType): MethodHandleType {
         if (leadingArgCount < 0) return topType
-        val parameterList = type.typeLatticeElementList as? CompleteTypeLatticeElementList ?: return topType
+        val parameterList = type.parameterTypes as? CompleteTypeLatticeElementList ?: return topType
         if (leadingArgCount >= parameterList.size) return topType
-        val keep = parameterList.parameterTypes.subList(0, leadingArgCount).toMutableList()
+        val keep = parameterList.typeList.subList(0, leadingArgCount).toMutableList()
         keep.add(ExactType(objectType.createArrayType()))
         return complete(type.returnType, keep)
     }
@@ -136,7 +136,7 @@ class MethodHandlesInitializer(private val ssaAnalyzer: SsaAnalyzer) : ProblemEm
         }
         val varHandleType = PsiType.getTypeByName(VAR_HANDLE_FQN, methodTypeExpr.project, methodTypeExpr.resolveScope)
         return type.withParameterTypes(
-                type.typeLatticeElementList.addAllAt(0, CompleteTypeList(listOf(ExactType(varHandleType))))
+                type.parameterTypes.addAllAt(0, CompleteTypeList(listOf(ExactType(varHandleType))))
             )
     }
 

--- a/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandlesMerger.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandlesMerger.kt
@@ -29,7 +29,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         val exType = exTypeExpr.asType()
         val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
         val handler = ssaAnalyzer.methodHandleType(handlerExpr, block) ?: bottomType
-        val handlerParameterTypes = handler.typeLatticeElementList
+        val handlerParameterTypes = handler.parameterTypes
         if (handlerParameterTypes is CompleteTypeLatticeElementList && (handlerParameterTypes.size == 0
                     || (exType is ExactType && !handlerParameterTypes[0].canBe(exType.psiType)))
         ) {
@@ -43,7 +43,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         }
         val comparableTypes = handlerParameterTypes.dropFirst(1)
         // TODO calculate common type of parameters
-        if (!comparableTypes.effectivelyIdenticalTo(target.typeLatticeElementList)) {
+        if (!comparableTypes.effectivelyIdenticalTo(target.parameterTypes)) {
             emitProblem<MethodHandleType>(
                 targetExpr,
                 message(
@@ -64,7 +64,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
     ): MethodHandleType {
         val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: return bottomType
         val filter = ssaAnalyzer.methodHandleType(filterExpr, block) ?: return bottomType
-        var parameters = target.typeLatticeElementList
+        var parameters = target.parameterTypes
         val pos = posExpr.nonNegativeInt() ?: return bottomType
         if (parameters is CompleteTypeLatticeElementList && pos >= parameters.size) {
             return emitProblem(
@@ -81,7 +81,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
             // the return value of filter will be passed to target at pos
             parameters = parameters.removeAt(pos)
         }
-        val filterParameters = filter.typeLatticeElementList
+        val filterParameters = filter.parameterTypes
         parameters = parameters.addAllAt(pos, filterParameters)
         return target.withParameterTypes(parameters)
     }
@@ -116,7 +116,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         }
         if (body is CompleteMethodHandleType) {
             val externalParameters: TypeList
-            val internalParameters = body.typeLatticeElementList
+            val internalParameters = body.parameterTypes
             val returnType = body.returnType
             if (init is CompleteMethodHandleType) {
                 if (returnType != init.returnType) {
@@ -132,7 +132,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
                 externalParameters = if (size != 1) {
                     internalParameters.dropFirst(1)
                 } else {
-                    (iterations as CompleteMethodHandleType).typeLatticeElementList
+                    (iterations as CompleteMethodHandleType).parameterTypes
                 }
             } else {
                 // (V I A...)
@@ -143,13 +143,13 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
                 externalParameters = if (size != 2) {
                     internalParameters.dropFirst(2)
                 } else {
-                    (iterations as CompleteMethodHandleType).typeLatticeElementList
+                    (iterations as CompleteMethodHandleType).parameterTypes
                 }
             }
-            if (!(init as CompleteMethodHandleType).typeLatticeElementList.effectivelyIdenticalTo(externalParameters)) {
+            if (!(init as CompleteMethodHandleType).parameterTypes.effectivelyIdenticalTo(externalParameters)) {
                 return topType
             }
-            if (!(iterations as CompleteMethodHandleType).typeLatticeElementList.effectivelyIdenticalTo(externalParameters)) {
+            if (!(iterations as CompleteMethodHandleType).parameterTypes.effectivelyIdenticalTo(externalParameters)) {
                 return topType
             }
         }
@@ -175,9 +175,9 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         if (start !is CompleteMethodHandleType || end !is CompleteMethodHandleType) {
             return bottomType // TODO not correct
         }
-        val startParameterList = start.typeLatticeElementList as? CompleteTypeLatticeElementList ?: return topType
-        val endParameterList = end.typeLatticeElementList as? CompleteTypeLatticeElementList ?: return topType
-        if (startParameterList.parameterTypes.effectivelyIdenticalTo(endParameterList.parameterTypes)) {
+        val startParameterList = start.parameterTypes as? CompleteTypeLatticeElementList ?: return topType
+        val endParameterList = end.parameterTypes as? CompleteTypeLatticeElementList ?: return topType
+        if (startParameterList.typeList.effectivelyIdenticalTo(endParameterList.typeList)) {
             return topType
         }
         // types otherwise must be equal to countedLoop(iterations, init, body)
@@ -196,8 +196,8 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         if (!pred.returnType.canBe(PsiTypes.booleanType())) {
             return topType
         }
-        val internalParams = (body as? CompleteMethodHandleType)?.typeLatticeElementList ?: return body
-        if (internalParams != ((pred as? CompleteMethodHandleType)?.typeLatticeElementList ?: return pred)) {
+        val internalParams = (body as? CompleteMethodHandleType)?.parameterTypes ?: return body
+        if (internalParams != ((pred as? CompleteMethodHandleType)?.parameterTypes ?: return pred)) {
             return topType
         }
         val returnType = init.returnType.join(body.returnType)
@@ -210,7 +210,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
             if (internalParams.hasSize(0) == TriState.YES) return topType
             if (internalParams[0].join(body.returnType) == TopType) return topType
             if (init !is CompleteMethodHandleType) return init
-            if (init.typeLatticeElementList != internalParams.dropFirst(1)) return topType
+            if (init.parameterTypes != internalParams.dropFirst(1)) return topType
         }
         // TODO this is not always correct due to effectively identical parameter lists
         return init
@@ -225,10 +225,10 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         val types = valueTypes.mapToTypes()
         val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
         val signature = target
-        if (signature.typeLatticeElementList.compareSize(pos) == PartialOrder.LT) {
-            return emitOutOfBounds(signature.typeLatticeElementList.sizeOrNull(), targetExpr, pos, false)
+        if (signature.parameterTypes.compareSize(pos) == PartialOrder.LT) {
+            return emitOutOfBounds(signature.parameterTypes.sizeOrNull(), targetExpr, pos, false)
         }
-        val list = signature.typeLatticeElementList.addAllAt(pos, CompleteTypeList(types))
+        val list = signature.parameterTypes.addAllAt(pos, CompleteTypeList(types))
         return signature.withParameterTypes(list)
     }
 
@@ -252,9 +252,9 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
         val newType = ssaAnalyzer.methodHandleType(newTypeExpr, block) ?: bottomType
         // TODO proper handling of bottom/top
-        val newTypeParameterList = newType.typeLatticeElementList
+        val newTypeParameterList = newType.parameterTypes
         if (newTypeParameterList !is CompleteTypeLatticeElementList) return newType // result param types unknown
-        val targetParameterList = target.typeLatticeElementList
+        val targetParameterList = target.parameterTypes
         if (targetParameterList !is CompleteTypeLatticeElementList) return target // source param types unknown
         if (targetParameterList.size != newTypeParameterList.size) return topType
         return newType
@@ -265,13 +265,13 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         if (target !is CompleteMethodHandleType) return target
         if (filters.any { it !is CompleteMethodHandleType }) return topType
         val targetSignature = target
-        val targetParameterList = targetSignature.typeLatticeElementList
+        val targetParameterList = targetSignature.parameterTypes
         if (targetParameterList.sizeMatches { pos + filters.size > it } == TriState.YES) return topType
         val filtersCast = filters.map { it as CompleteMethodHandleType }
         // filters must be unary operators T1 -> T2
-        if (filtersCast.any { it.typeLatticeElementList.hasSize(1) == TriState.NO }) return topType
+        if (filtersCast.any { it.parameterTypes.hasSize(1) == TriState.NO }) return topType
         // return type of filters[i] must be type of targetParameters[i + pos]
-        val targetParams = (targetParameterList as? CompleteTypeLatticeElementList ?: return topType).parameterTypes
+        val targetParams = (targetParameterList as? CompleteTypeLatticeElementList ?: return topType).typeList
         if (targetParams.subList(pos)
                 .zip(filtersCast)
                 .any { (psiType, mhType) -> psiType.join(mhType.returnType) == TopType }
@@ -279,7 +279,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
             return topType
         // replace parameter types in range of [pos, pos + filters.size)
         val result = targetParams.mapIndexed { index, psiType ->
-            if (index >= pos && index - pos < filters.size) filtersCast[index - pos].typeLatticeElementList[0]
+            if (index >= pos && index - pos < filters.size) filtersCast[index - pos].parameterTypes[0]
             else psiType
         }
         return targetSignature.withParameterTypes(result)
@@ -295,10 +295,10 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
         val filter = ssaAnalyzer.methodHandleType(filterExpr, block) ?: bottomType
         // TODO proper handling of bottom/top
-        if (filter !is CompleteMethodHandleType || filter.typeLatticeElementList.hasSize(1) == TriState.NO) {
+        if (filter !is CompleteMethodHandleType || filter.parameterTypes.hasSize(1) == TriState.NO) {
             return topType
         }
-        if (target.returnType.join(filter.typeLatticeElementList[0]) == TopType) return topType
+        if (target.returnType.join(filter.parameterTypes[0]) == TopType) return topType
         return target.withReturnType(filter.returnType)
     }
 
@@ -308,16 +308,16 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         // TODO proper handling of bottom/top
         val targetSignature = target // (Z..., V, A[N]..., B...)T, where N = |combiner.parameters|
         val combinerSignature = combiner // (A...)V
-        if (targetSignature.typeLatticeElementList.sizeMatches { pos >= it } == TriState.YES) return topType
+        if (targetSignature.parameterTypes.sizeMatches { pos >= it } == TriState.YES) return topType
         val combinerIsVoid = combinerSignature.returnType.match(PsiTypes.voidType())
-        val combinerParameterList = combinerSignature.typeLatticeElementList as? CompleteTypeLatticeElementList ?: return topType
+        val combinerParameterList = combinerSignature.parameterTypes as? CompleteTypeLatticeElementList ?: return topType
         val sub: List<Type> = when (combinerIsVoid) {
-            TriState.YES -> combinerParameterList.parameterTypes
-            TriState.NO -> listOf(combinerSignature.returnType) + combinerParameterList.parameterTypes
+            TriState.YES -> combinerParameterList.typeList
+            TriState.NO -> listOf(combinerSignature.returnType) + combinerParameterList.typeList
             TriState.UNKNOWN -> return target.withParameterTypes(TopTypeList)
         }
         // TODO type-check sub with existing list
-        var newParameters = targetSignature.typeLatticeElementList
+        var newParameters = targetSignature.parameterTypes
         if (combinerIsVoid == TriState.NO) {
             newParameters = newParameters.removeAt(pos)
         }
@@ -339,10 +339,10 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         val fallbackSignature = fallback // (A... B...)T
         if (!testSignature.returnType.canBe(PsiTypes.booleanType())) return topType
         if (targetSignature != fallbackSignature) return topType
-        val testParameterList = testSignature.typeLatticeElementList as? CompleteTypeLatticeElementList ?: return topType
-        val targetParameterList = targetSignature.typeLatticeElementList as? CompleteTypeLatticeElementList ?: return topType
+        val testParameterList = testSignature.parameterTypes as? CompleteTypeLatticeElementList ?: return topType
+        val targetParameterList = targetSignature.parameterTypes as? CompleteTypeLatticeElementList ?: return topType
         if (testParameterList.size > targetParameterList.size) return topType
-        if (testParameterList.parameterTypes != targetParameterList.parameterTypes.subList(
+        if (testParameterList.typeList != targetParameterList.typeList.subList(
                 0,
                 testParameterList.size
             )
@@ -360,7 +360,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
     ): MethodHandleType {
         val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
         val pos = posExpr.nonNegativeInt() ?: return topType
-        val parameterList = target.typeLatticeElementList
+        val parameterList = target.parameterTypes
         if (parameterList.compareSize(pos + valueTypes.size) == PartialOrder.LT) {
             // the index of the first value that is out of bounds
             val valueTypesIndex = parameterList.sizeOrNull()?.minus(pos)
@@ -391,8 +391,8 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         if (target.returnType.join(newType.returnType) == TopType) {
             return emitIncompatibleReturnTypes(targetExpr, target.returnType, newType.returnType)
         }
-        val outParams = target.typeLatticeElementList
-        val inParams = newType.typeLatticeElementList
+        val outParams = target.parameterTypes
+        val inParams = newType.parameterTypes
         if (outParams.sizeMatches { it != reorder.size } == TriState.YES) {
             return emitProblem(
                 newTypeExpr,
@@ -401,8 +401,8 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         }
         // if reorder array is unknown, just assume the input is correct
         val reorderInts = reorder.map { it.nonNegativeInt() ?: return newType }
-        val resultType: MutableList<Type> = (newType.typeLatticeElementList as? CompleteTypeLatticeElementList)
-            ?.parameterTypes?.toMutableList()
+        val resultType: MutableList<Type> = (newType.parameterTypes as? CompleteTypeLatticeElementList)
+            ?.typeList?.toMutableList()
             ?: return topType
         for ((index, value) in reorderInts.withIndex()) {
             if (inParams.compareSize(value + 1) == PartialOrder.LT) {
@@ -437,10 +437,10 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
             emitProblem<MethodHandleType>(fallbackExpr.parent, message("problem.merging.tableSwitch.noCases"))
         }
         val fallback = ssaAnalyzer.methodHandleType(fallbackExpr, block) ?: bottomType
-        var error = checkFirstParameter(fallback.typeLatticeElementList, fallbackExpr)
+        var error = checkFirstParameter(fallback.parameterTypes, fallbackExpr)
         val targets = targetsExprs.map { ssaAnalyzer.methodHandleType(it, block) ?: bottomType }
         for ((index, target) in targets.withIndex()) {
-            error = error or checkFirstParameter(target.typeLatticeElementList, targetsExprs[index])
+            error = error or checkFirstParameter(target.parameterTypes, targetsExprs[index])
         }
         val cases = targets.map { it }
         var prev = fallback
@@ -484,12 +484,12 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
             TriState.NO -> 2
             TriState.UNKNOWN -> return complete(target.returnType, TopTypeList)
         }
-        if (cleanup.typeLatticeElementList.sizeMatches { it < leading } == TriState.YES) return topType
+        if (cleanup.parameterTypes.sizeMatches { it < leading } == TriState.YES) return topType
         // TODO 0th param must be <= Throwable
-        if (isVoid == TriState.NO && cleanup.typeLatticeElementList[1] != cleanup.returnType) return topType
-        val aList = cleanup.typeLatticeElementList.dropFirst(leading) as? CompleteTypeLatticeElementList ?: return topType
-        val targetParameterList = target.typeLatticeElementList as? CompleteTypeLatticeElementList ?: return topType
-        if (!targetParameterList.parameterTypes.startsWith(aList.parameterTypes)) return topType
+        if (isVoid == TriState.NO && cleanup.parameterTypes[1] != cleanup.returnType) return topType
+        val aList = cleanup.parameterTypes.dropFirst(leading) as? CompleteTypeLatticeElementList ?: return topType
+        val targetParameterList = target.parameterTypes as? CompleteTypeLatticeElementList ?: return topType
+        if (!targetParameterList.typeList.startsWith(aList.typeList)) return topType
         return target
     }
 
@@ -514,7 +514,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
 
 private fun TypeList.effectivelyIdenticalTo(other: TypeList): Boolean {
     if (this is CompleteTypeList && other is CompleteTypeList) {
-        return parameterTypes.effectivelyIdenticalTo(other.parameterTypes)
+        return typeList.effectivelyIdenticalTo(other.typeList)
     }
     return false
 }

--- a/src/main/kotlin/de/sirywell/handlehints/presentation/TypeDocumentationTarget.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/presentation/TypeDocumentationTarget.kt
@@ -1,0 +1,34 @@
+package de.sirywell.handlehints.presentation
+
+import com.intellij.model.Pointer
+import com.intellij.platform.backend.documentation.DocumentationResult
+import com.intellij.platform.backend.documentation.DocumentationTarget
+import com.intellij.platform.backend.presentation.TargetPresentation
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiIdentifier
+import com.intellij.refactoring.suggested.createSmartPointer
+import de.sirywell.handlehints.TypeData
+
+@Suppress("UnstableApiUsage")
+class TypeDocumentationTarget(private val identifier: PsiIdentifier, private val element: PsiElement) :
+    DocumentationTarget {
+    override fun computePresentation(): TargetPresentation {
+        return TargetPresentation.builder("Analysed Type")
+            .presentation()
+    }
+
+    override fun createPointer(): Pointer<out DocumentationTarget> {
+        val idPointer = identifier.createSmartPointer()
+        val elPointer = element.createSmartPointer()
+        return Pointer {
+            val identifier = idPointer.element ?: return@Pointer null
+            val element = elPointer.element ?: return@Pointer null
+            TypeDocumentationTarget(identifier, element)
+        }
+    }
+
+    override fun computeDocumentation(): DocumentationResult? {
+        val type = TypeData.forFile(element.containingFile)[element.parent] ?: return null
+        return DocumentationResult.documentation("<code>${TypePrinter().print(type)}</code>")
+    }
+}

--- a/src/main/kotlin/de/sirywell/handlehints/presentation/TypeDocumentationTargetProvider.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/presentation/TypeDocumentationTargetProvider.kt
@@ -1,0 +1,25 @@
+package de.sirywell.handlehints.presentation
+
+import com.intellij.platform.backend.documentation.DocumentationTarget
+import com.intellij.platform.backend.documentation.PsiDocumentationTargetProvider
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiIdentifier
+import com.intellij.psi.PsiReferenceExpression
+import com.intellij.psi.PsiVariable
+
+class TypeDocumentationTargetProvider : PsiDocumentationTargetProvider {
+
+    override fun documentationTarget(element: PsiElement, originalElement: PsiElement?): DocumentationTarget? {
+        if (originalElement is PsiIdentifier && isVariableName(originalElement)) {
+            return TypeDocumentationTarget(originalElement, element)
+        }
+        return null
+    }
+
+    private fun isVariableName(originalElement: PsiIdentifier): Boolean {
+        if (originalElement.parent is PsiVariable) {
+            return (originalElement.parent as PsiVariable).nameIdentifier == originalElement
+        }
+        return originalElement.parent is PsiReferenceExpression
+    }
+}

--- a/src/main/kotlin/de/sirywell/handlehints/presentation/TypeInlayHintsCollector.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/presentation/TypeInlayHintsCollector.kt
@@ -1,8 +1,6 @@
-package de.sirywell.handlehints
+package de.sirywell.handlehints.presentation
 
-import com.intellij.codeInsight.hints.declarative.InlayTreeSink
-import com.intellij.codeInsight.hints.declarative.InlineInlayPosition
-import com.intellij.codeInsight.hints.declarative.SharedBypassCollector
+import com.intellij.codeInsight.hints.declarative.*
 import com.intellij.psi.PsiAssignmentExpression
 import com.intellij.psi.PsiDeclarationStatement
 import com.intellij.psi.PsiElement
@@ -10,9 +8,11 @@ import com.intellij.psi.PsiParameterList
 import com.intellij.psi.PsiReferenceExpression
 import com.intellij.refactoring.suggested.endOffset
 import com.intellij.refactoring.suggested.startOffset
+import de.sirywell.handlehints.TypeData
+import de.sirywell.handlehints.getVariable
 import de.sirywell.handlehints.type.*
 
-class MethodTypeInlayHintsCollector : SharedBypassCollector {
+class TypeInlayHintsCollector : SharedBypassCollector {
 
     override fun collectFromElement(element: PsiElement, sink: InlayTreeSink) {
         val (pos, belongsToBefore) = when (element) {
@@ -38,7 +38,7 @@ class MethodTypeInlayHintsCollector : SharedBypassCollector {
             return
         }
         sink.addPresentation(InlineInlayPosition(pos, belongsToBefore), hasBackground = true) {
-            text(type.toString())
+            text(TypePrinter().print(type))
         }
     }
 }

--- a/src/main/kotlin/de/sirywell/handlehints/presentation/TypeInlayProvider.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/presentation/TypeInlayProvider.kt
@@ -1,4 +1,4 @@
-package de.sirywell.handlehints
+package de.sirywell.handlehints.presentation
 
 import com.intellij.codeInsight.hints.declarative.InlayHintsProvider
 import com.intellij.openapi.components.service
@@ -6,13 +6,13 @@ import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.DumbService
 import com.intellij.psi.PsiFile
 
-class MethodTypeInlayProvider : InlayHintsProvider {
+class TypeInlayProvider : InlayHintsProvider {
 
     override fun createCollector(
         file: PsiFile,
         editor: Editor
     ): com.intellij.codeInsight.hints.declarative.InlayHintsCollector? {
         if (file.project.service<DumbService>().isDumb) return null
-        return MethodTypeInlayHintsCollector()
+        return TypeInlayHintsCollector()
     }
 }

--- a/src/main/kotlin/de/sirywell/handlehints/presentation/TypePrinter.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/presentation/TypePrinter.kt
@@ -1,0 +1,125 @@
+package de.sirywell.handlehints.presentation
+
+import de.sirywell.handlehints.type.*
+
+class TypePrinter : TypeVisitor<StringBuilder, Unit> {
+
+    fun print(type: TypeLatticeElement<*>): String {
+        val stringBuilder = StringBuilder()
+        type.accept(this, stringBuilder)
+        return stringBuilder.toString()
+    }
+
+    override fun visit(type: BotType, context: StringBuilder) {
+        context.append("⊥")
+    }
+
+    override fun visit(type: TopType, context: StringBuilder) {
+        context.append("⊤")
+    }
+
+    override fun visit(type: ExactType, context: StringBuilder) {
+        context.append(type.psiType.presentableText)
+    }
+
+    override fun visit(type: TopTypeList, context: StringBuilder) {
+        context.append("({⊤})")
+    }
+
+    override fun visit(type: BotTypeList, context: StringBuilder) {
+        context.append("({⊥})")
+    }
+
+    override fun visit(type: CompleteTypeList, context: StringBuilder) {
+        context.append("(")
+        type.typeList.forEachIndexed { index, t ->
+            if (index != 0) {
+                context.append(",")
+            }
+            t.accept(this, context)
+        }
+        context.append(")")
+    }
+
+    override fun visit(type: IncompleteTypeList, context: StringBuilder) {
+        context.append("(")
+        type.knownTypes.onEachIndexed { index, (pos, t) ->
+            if (index != 0) {
+                context.append(",")
+            }
+            context.append(pos).append("=")
+            t.accept(this, context)
+        }
+        context.append(")")
+    }
+
+    override fun visit(type: BotVarHandleType, context: StringBuilder) {
+        context.append("⊥")
+    }
+
+    override fun visit(type: TopVarHandleType, context: StringBuilder) {
+        context.append("⊤")
+    }
+
+    override fun visit(type: CompleteVarHandleType, context: StringBuilder) {
+        type.coordinateTypes.accept(this, context)
+        type.variableType.accept(this, context)
+    }
+
+    override fun visit(type: BotMethodHandleType, context: StringBuilder) {
+        context.append("⊥")
+    }
+
+    override fun visit(type: TopMethodHandleType, context: StringBuilder) {
+        context.append("⊤")
+    }
+
+    override fun visit(type: CompleteMethodHandleType, context: StringBuilder) {
+        type.parameterTypes.accept(this, context)
+        type.returnType.accept(this, context)
+    }
+
+    override fun visit(type: BotMemoryLayoutType, context: StringBuilder) {
+        context.append("⊥")
+    }
+
+    override fun visit(type: TopMemoryLayoutType, context: StringBuilder) {
+        context.append("⊤")
+    }
+
+    override fun visit(type: ValueLayoutType, context: StringBuilder) {
+        if (type.byteSize == null || type.byteSize != type.byteAlignment) {
+            context.append(type.byteAlignment ?: "?").append("%")
+        }
+        type.type.accept(this, context)
+        context.append(type.byteSize ?: "?")
+    }
+
+    override fun visit(type: StructLayoutType, context: StringBuilder) {
+        if (type.byteSize == null || type.byteSize != type.byteAlignment) {
+            context.append(type.byteAlignment ?: "?").append("%")
+        }
+        type.memberLayouts.accept(this, context)
+    }
+
+    override fun visit(type: TopMemoryLayoutList, context: StringBuilder) {
+        context.append("[{⊤}]")
+    }
+
+    override fun visit(type: BotMemoryLayoutList, context: StringBuilder) {
+        context.append("[{⊥}]")
+    }
+
+    override fun visit(type: CompleteMemoryLayoutList, context: StringBuilder) {
+        context.append("[")
+        type.typeList.forEach { it.accept(this, context) }
+        context.append("]")
+    }
+
+    override fun visit(type: IncompleteMemoryLayoutList, context: StringBuilder) {
+        context.append("[")
+        (0..type.knownTypes.lastKey()).map { type.parameterType(it) }.forEach { it.accept(this, context) }
+        context.append("]")
+    }
+
+}

--- a/src/main/kotlin/de/sirywell/handlehints/presentation/TypePrinter.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/presentation/TypePrinter.kt
@@ -63,7 +63,9 @@ class TypePrinter : TypeVisitor<StringBuilder, Unit> {
 
     override fun visit(type: CompleteVarHandleType, context: StringBuilder) {
         type.coordinateTypes.accept(this, context)
+        context.append("(")
         type.variableType.accept(this, context)
+        context.append(")")
     }
 
     override fun visit(type: BotMethodHandleType, context: StringBuilder) {

--- a/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
@@ -131,7 +131,7 @@ fun objectType(manager: PsiManager, scope: GlobalSearchScope): PsiType {
 fun findMethodMatching(methodHandleType: MethodHandleType, methods: Array<PsiMethod>): PsiMethod? {
     if (methodHandleType !is CompleteMethodHandleType) return null
     if (methodHandleType.returnType !is ExactType) return null
-    val parameterList = methodHandleType.typeLatticeElementList as? CompleteTypeList ?: return null
+    val parameterList = methodHandleType.parameterTypes as? CompleteTypeList ?: return null
     return methods.find { matches(it, methodHandleType.returnType as ExactType, parameterList) }
 }
 
@@ -142,7 +142,7 @@ fun matches(method: PsiMethod, returnType: ExactType, parameterList: CompleteTyp
         }
     } else if (method.returnType != returnType.psiType) return false
     if (parameterList.size != method.parameterList.parametersCount) return false
-    val ps = parameterList.parameterTypes.map { it as? ExactType ?: return false }.map { it.psiType }
+    val ps = parameterList.typeList.map { it as? ExactType ?: return false }.map { it.psiType }
     return method.parameterList.parameters
         .map { if (it.type is PsiEllipsisType) (it.type as PsiEllipsisType).toArrayType() else it.type }
         .foldIndexed(true) { index, acc, param -> acc && ps[index] == param }

--- a/src/main/kotlin/de/sirywell/handlehints/type/MemoryLayoutType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/MemoryLayoutType.kt
@@ -17,22 +17,17 @@ data object BotMemoryLayoutType : MemoryLayoutType, BotTypeLatticeElement<Memory
 
     override val byteAlignment = null
     override val byteSize = null
-
-    override fun toString(): String {
-        return "⊥"
-    }
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
 }
 
 data object TopMemoryLayoutType : MemoryLayoutType, TopTypeLatticeElement<MemoryLayoutType> {
     override fun self() = this
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
+
     override fun withByteAlignment(byteAlignment: Long) = this
 
     override val byteAlignment = null
     override val byteSize = null
-
-    override fun toString(): String {
-        return "⊤"
-    }
 }
 
 val ADDRESS_TYPE = ExactType(PsiTypes.nullType())
@@ -57,13 +52,9 @@ data class ValueLayoutType(
         return TopMemoryLayoutType to TriState.UNKNOWN
     }
 
-    override fun withByteAlignment(byteAlignment: Long) = ValueLayoutType(type, byteAlignment, byteSize)
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
 
-    override fun toString(): String {
-        return (if (byteAlignment != null) "$byteAlignment%" else "?") +
-                "$type" +
-                if (byteSize != null) "$byteSize" else "?"
-    }
+    override fun withByteAlignment(byteAlignment: Long) = ValueLayoutType(type, byteAlignment, byteSize)
 }
 
 data class StructLayoutType(
@@ -87,12 +78,7 @@ data class StructLayoutType(
         ) to identical.sharpenTowardsNo(identicalAlignment).sharpenTowardsNo(identicalSize)
     }
 
-    override fun toString(): String {
-        return (if (byteAlignment != null) "$byteAlignment%" else "?") +
-                "$memberLayouts" +
-                if (byteSize != null) "$byteSize" else "?"
-    }
-
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
 }
 
 private fun joinSizeAndAlignment(first: MemoryLayoutType, second: MemoryLayoutType): Pair<TriState, TriState> {
@@ -108,6 +94,7 @@ data object TopMemoryLayoutList : TopTypeLatticeElementList<MemoryLayoutType>() 
     override fun botList() = BotMemoryLayoutList
     override fun top() = TopMemoryLayoutType
     override fun bot() = BotMemoryLayoutType
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
     override fun complete(list: List<MemoryLayoutType>) = CompleteMemoryLayoutList(list)
     override fun incomplete(list: SortedMap<Int, MemoryLayoutType>) = IncompleteMemoryLayoutList(list)
 
@@ -118,6 +105,7 @@ data object BotMemoryLayoutList : BotTypeLatticeElementList<MemoryLayoutType>() 
     override fun botList() = BotMemoryLayoutList
     override fun top() = TopMemoryLayoutType
     override fun bot() = BotMemoryLayoutType
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
     override fun complete(list: List<MemoryLayoutType>) = CompleteMemoryLayoutList(list)
     override fun incomplete(list: SortedMap<Int, MemoryLayoutType>) = IncompleteMemoryLayoutList(list)
 }
@@ -127,6 +115,7 @@ class CompleteMemoryLayoutList(list: List<MemoryLayoutType>) : CompleteTypeLatti
     override fun botList() = BotMemoryLayoutList
     override fun top() = TopMemoryLayoutType
     override fun bot() = BotMemoryLayoutType
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
     override fun complete(list: List<MemoryLayoutType>) = CompleteMemoryLayoutList(list)
     override fun incomplete(list: SortedMap<Int, MemoryLayoutType>) = IncompleteMemoryLayoutList(list)
 }
@@ -137,6 +126,7 @@ class IncompleteMemoryLayoutList(knowParameterTypes: SortedMap<Int, MemoryLayout
     override fun botList() = BotMemoryLayoutList
     override fun top() = TopMemoryLayoutType
     override fun bot() = BotMemoryLayoutType
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
     override fun complete(list: List<MemoryLayoutType>) = CompleteMemoryLayoutList(list)
     override fun incomplete(list: SortedMap<Int, MemoryLayoutType>) = IncompleteMemoryLayoutList(list)
 }

--- a/src/main/kotlin/de/sirywell/handlehints/type/MethodHandleType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/MethodHandleType.kt
@@ -16,7 +16,7 @@ sealed interface MethodHandleType : TypeLatticeElement<MethodHandleType> {
 
     val returnType: Type
 
-    val typeLatticeElementList: TypeList
+    val parameterTypes: TypeList
 
     val varargs: TriState
 }
@@ -24,7 +24,8 @@ sealed interface MethodHandleType : TypeLatticeElement<MethodHandleType> {
 data object BotMethodHandleType : MethodHandleType, BotTypeLatticeElement<MethodHandleType> {
     override fun joinIdentical(other: MethodHandleType) = other to TriState.UNKNOWN
 
-    override fun withReturnType(returnType: Type) = CompleteMethodHandleType(returnType, typeLatticeElementList, TriState.NO)
+    override fun withReturnType(returnType: Type) =
+        CompleteMethodHandleType(returnType, parameterTypes, TriState.NO)
 
     override fun withParameterTypes(parameterTypes: TypeList) =
         CompleteMethodHandleType(returnType, parameterTypes, TriState.NO)
@@ -35,10 +36,13 @@ data object BotMethodHandleType : MethodHandleType, BotTypeLatticeElement<Method
 
     override val returnType get() = BotType
 
-    override val typeLatticeElementList get() = BotTypeList
+    override val parameterTypes get() = BotTypeList
 
     override val varargs get() = TriState.UNKNOWN
+
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
 }
+
 
 data object TopMethodHandleType : MethodHandleType, TopTypeLatticeElement<MethodHandleType> {
     override fun joinIdentical(other: MethodHandleType) = this to TriState.UNKNOWN
@@ -53,26 +57,29 @@ data object TopMethodHandleType : MethodHandleType, TopTypeLatticeElement<Method
 
     override val returnType get() = TopType
 
-    override val typeLatticeElementList get() = TopTypeList
+    override val parameterTypes get() = TopTypeList
 
     override val varargs get() = TriState.UNKNOWN
     override fun self() = this
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
 }
 
 @JvmRecord
 data class CompleteMethodHandleType(
     override val returnType: Type,
-    override val typeLatticeElementList: TypeList,
+    override val parameterTypes: TypeList,
     override val varargs: TriState
 ) : MethodHandleType {
     override fun joinIdentical(other: MethodHandleType): Pair<MethodHandleType, TriState> {
         val (ret, rIdentical) = returnType.joinIdentical(other.returnType)
-        val (params, pIdentical) = typeLatticeElementList.joinIdentical(other.typeLatticeElementList)
+        val (params, pIdentical) = parameterTypes.joinIdentical(other.parameterTypes)
         return CompleteMethodHandleType(ret, params, TriState.NO) to rIdentical.sharpenTowardsNo(pIdentical)
     }
 
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
+
     override fun withReturnType(returnType: Type): MethodHandleType {
-        return CompleteMethodHandleType(returnType, typeLatticeElementList, TriState.NO)
+        return CompleteMethodHandleType(returnType, parameterTypes, TriState.NO)
     }
 
     override fun withParameterTypes(parameterTypes: TypeList): MethodHandleType {
@@ -80,15 +87,15 @@ data class CompleteMethodHandleType(
     }
 
     override fun withVarargs(varargs: TriState): MethodHandleType {
-        return CompleteMethodHandleType(returnType, typeLatticeElementList, varargs)
+        return CompleteMethodHandleType(returnType, parameterTypes, varargs)
     }
 
     override fun parameterTypeAt(index: Int): Type {
-        return typeLatticeElementList[index]
+        return parameterTypes[index]
     }
 
     override fun toString(): String {
-        return typeLatticeElementList.toString() + returnType
+        return parameterTypes.toString() + returnType
     }
 
 }

--- a/src/main/kotlin/de/sirywell/handlehints/type/Type.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/Type.kt
@@ -23,22 +23,18 @@ sealed interface Type : TypeLatticeElement<Type> {
 
 data object BotType : Type {
     override fun joinIdentical(other: Type) = other to TriState.UNKNOWN
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
+
     override fun erase(manager: PsiManager, scope: GlobalSearchScope) = this
     override fun match(psiType: PsiType) = TriState.UNKNOWN
-
-    override fun toString(): String {
-        return "⊥"
-    }
 }
 
 data object TopType : Type {
     override fun joinIdentical(other: Type) = this to TriState.UNKNOWN
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
+
     override fun erase(manager: PsiManager, scope: GlobalSearchScope) = this
     override fun match(psiType: PsiType) = TriState.UNKNOWN
-
-    override fun toString(): String {
-        return "⊤"
-    }
 }
 
 @JvmRecord
@@ -77,6 +73,8 @@ data class ExactType(val psiType: PsiType) : Type {
         }
     }
 
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
+
     override fun erase(manager: PsiManager, scope: GlobalSearchScope): Type {
         if (psiType is PsiPrimitiveType) return this
         val objectType = objectType(manager, scope)
@@ -100,6 +98,7 @@ data object TopTypeList : TopTypeLatticeElementList<Type>() {
     override fun botList() = BotTypeList
     override fun top() = TopType
     override fun bot() = BotType
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
     override fun complete(list: List<Type>) = CompleteTypeList(list)
     override fun incomplete(list: SortedMap<Int, Type>) = IncompleteTypeList(list)
 
@@ -109,6 +108,7 @@ data object BotTypeList : BotTypeLatticeElementList<Type>() {
     override fun botList() = BotTypeList
     override fun top() = TopType
     override fun bot() = BotType
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
     override fun complete(list: List<Type>) = CompleteTypeList(list)
     override fun incomplete(list: SortedMap<Int, Type>) = IncompleteTypeList(list)
 }
@@ -118,6 +118,7 @@ class CompleteTypeList(list: List<Type>) : CompleteTypeLatticeElementList<Type>(
     override fun botList() = BotTypeList
     override fun top() = TopType
     override fun bot() = BotType
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
     override fun complete(list: List<Type>) = CompleteTypeList(list)
     override fun incomplete(list: SortedMap<Int, Type>) = IncompleteTypeList(list)
 }
@@ -127,6 +128,7 @@ class IncompleteTypeList(knowParameterTypes: SortedMap<Int, Type>) : IncompleteT
     override fun botList() = BotTypeList
     override fun top() = TopType
     override fun bot() = BotType
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
     override fun complete(list: List<Type>) = CompleteTypeList(list)
     override fun incomplete(list: SortedMap<Int, Type>) = IncompleteTypeList(list)
 }

--- a/src/main/kotlin/de/sirywell/handlehints/type/TypeLatticeElement.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/TypeLatticeElement.kt
@@ -9,6 +9,7 @@ import kotlin.reflect.full.isSubclassOf
 sealed interface TypeLatticeElement<LE: TypeLatticeElement<LE>> {
     fun join(other: LE) = joinIdentical(other).first
     fun joinIdentical(other: LE): Pair<LE, TriState>
+    fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C): R
 }
 
 sealed interface BotTypeLatticeElement<LE: TypeLatticeElement<LE>> : TypeLatticeElement<LE> {

--- a/src/main/kotlin/de/sirywell/handlehints/type/TypeVisitor.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/TypeVisitor.kt
@@ -1,0 +1,26 @@
+package de.sirywell.handlehints.type
+
+interface TypeVisitor<C, R> {
+
+    fun visit(type: BotType, context: C): R
+    fun visit(type: TopType, context: C): R
+    fun visit(type: ExactType, context: C): R
+    fun visit(type: TopTypeList, context: C): R
+    fun visit(type: BotTypeList, context: C): R
+    fun visit(type: CompleteTypeList, context: C): R
+    fun visit(type: IncompleteTypeList, context: C): R
+    fun visit(type: BotVarHandleType, context: C): R
+    fun visit(type: TopVarHandleType, context: C): R
+    fun visit(type: CompleteVarHandleType, context: C): R
+    fun visit(type: BotMethodHandleType, context: C): R
+    fun visit(type: TopMethodHandleType, context: C): R
+    fun visit(type: CompleteMethodHandleType, context: C): R
+    fun visit(type: BotMemoryLayoutType, context: C): R
+    fun visit(type: TopMemoryLayoutType, context: C): R
+    fun visit(type: ValueLayoutType, context: C): R
+    fun visit(type: StructLayoutType, context: C): R
+    fun visit(type: TopMemoryLayoutList, context: C): R
+    fun visit(type: BotMemoryLayoutList, context: C): R
+    fun visit(type: CompleteMemoryLayoutList, context: C): R
+    fun visit(type: IncompleteMemoryLayoutList, context: C): R
+}

--- a/src/main/kotlin/de/sirywell/handlehints/type/VarHandleType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/VarHandleType.kt
@@ -10,10 +10,13 @@ interface VarHandleType : TypeLatticeElement<VarHandleType> {
 data object BotVarHandleType : VarHandleType, BotTypeLatticeElement<VarHandleType> {
     override val variableType = BotType
     override val coordinateTypes = BotTypeList
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
 }
 
 data object TopVarHandleType : VarHandleType, TopTypeLatticeElement<VarHandleType> {
     override fun self() = this
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
+
     override val variableType = TopType
     override val coordinateTypes = TopTypeList
 }
@@ -35,9 +38,6 @@ data class CompleteVarHandleType(
         return CompleteVarHandleType(vt, ct) to identical
     }
 
-    override fun toString(): String {
-        return "$coordinateTypes($variableType)"
-    }
-
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
 }
 

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -21,9 +21,12 @@
                          shortName="MhMerge"
                          level="WARNING" enabledByDefault="true" language="JAVA"/>
         <codeInsight.declarativeInlayProvider language="JAVA"
-                                              implementationClass="de.sirywell.handlehints.MethodTypeInlayProvider"
+                                              implementationClass="de.sirywell.handlehints.presentation.TypeInlayProvider"
                                               group="TYPES_GROUP" isEnabledByDefault="true" nameKey="name"
                                               providerId="HandleHints-Java"/>
+        <platform.backend.documentation.psiTargetProvider
+                id="TypeDocumentationTargetProvider"
+                implementation="de.sirywell.handlehints.presentation.TypeDocumentationTargetProvider"/>
     </extensions>
 
     <applicationListeners>

--- a/src/test/kotlin/de/sirywell/handlehints/mhtype/MethodHandleTypeHelperInspection.kt
+++ b/src/test/kotlin/de/sirywell/handlehints/mhtype/MethodHandleTypeHelperInspection.kt
@@ -7,6 +7,7 @@ import com.intellij.psi.JavaElementVisitor
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiElementVisitor
 import de.sirywell.handlehints.TypeData
+import de.sirywell.handlehints.presentation.TypePrinter
 
 /**
  * We (mis)use this inspection to add the type info as highlighting to the source code.
@@ -20,7 +21,7 @@ class MethodHandleTypeHelperInspection(private val elementFilter: (PsiElement) -
             override fun visitElement(element: PsiElement) {
                 if (!elementFilter(element)) return
                 val foundType = TypeData.forFile(element.containingFile)[element] ?: return
-                holder.registerProblem(element, foundType.toString(), ProblemHighlightType.INFORMATION)
+                holder.registerProblem(element, TypePrinter().print(foundType), ProblemHighlightType.INFORMATION)
             }
         }
     }

--- a/src/test/testData/FinalFields.java
+++ b/src/test/testData/FinalFields.java
@@ -27,12 +27,12 @@ public class FinalFields {
         <info descr="(CharSequence)int">this.methodType = <info descr="(CharSequence)int">MethodType.methodType(int.class, CharSequence.class)</info></info>;
         <info descr="(CharSequence)int">MethodHandle mn = <info descr="(CharSequence)int">MethodHandles.empty(this.methodType)</info>;</info>
         <info descr="(CharSequence)int">MethodHandle mni = <info descr="(CharSequence)int">MethodHandles.empty(methodType)</info>;</info>
-        <info descr="TopMethodHandleType">MethodHandle o = <info descr="TopMethodHandleType">MethodHandles.empty(other.methodType)</info>;</info>
+        <info descr="⊤">MethodHandle o = <info descr="⊤">MethodHandles.empty(other.methodType)</info>;</info>
         if (Math.random() < 0.5) {
             other = this;
-            <info descr="TopMethodHandleType">MethodHandle oy = <info descr="TopMethodHandleType">MethodHandles.empty(other.methodType)</info>;</info>
+            <info descr="⊤">MethodHandle oy = <info descr="⊤">MethodHandles.empty(other.methodType)</info>;</info>
         }
-        <info descr="TopMethodHandleType">MethodHandle om = <info descr="TopMethodHandleType">MethodHandles.empty(other.methodType)</info>;</info>
+        <info descr="⊤">MethodHandle om = <info descr="⊤">MethodHandles.empty(other.methodType)</info>;</info>
     }
 
     void m() {

--- a/src/test/testData/InitialTypes.java
+++ b/src/test/testData/InitialTypes.java
@@ -7,13 +7,13 @@ public class InitialTypes {
     void m(MethodType mt, boolean b, Inner inner) {
         MethodHandle mh0;
         if (b) {
-            <info descr="TopMethodHandleType">mh0 = <info descr="TopMethodHandleType">MethodHandles.empty(mt)</info></info>;
+            <info descr="⊤">mh0 = <info descr="⊤">MethodHandles.empty(mt)</info></info>;
         } else {
             <info descr="()int">mh0 = <info descr="()int">MethodHandles.zero(int.class)</info></info>;
         }
-        <info descr="TopMethodHandleType">MethodHandle mh1 = <info descr="TopMethodHandleType">myMethodHandleMethod()</info>;</info>
-        <info descr="TopMethodHandleType">MethodHandle mh2 = inner.methodHandle;</info>
-        <info descr="TopMethodHandleType">MethodHandle mh3 = create().methodHandle;</info>
+        <info descr="⊤">MethodHandle mh1 = <info descr="⊤">myMethodHandleMethod()</info>;</info>
+        <info descr="⊤">MethodHandle mh2 = inner.methodHandle;</info>
+        <info descr="⊤">MethodHandle mh3 = create().methodHandle;</info>
     }
 
     private MethodHandle myMethodHandleMethod() {

--- a/src/test/testData/MemoryLayoutStructLayout.java
+++ b/src/test/testData/MemoryLayoutStructLayout.java
@@ -3,10 +3,10 @@ import java.lang.foreign.ValueLayout;
 
 class MemoryLayoutStructLayout {
     void m() {
-        <info descr="4%int4">ValueLayout vl0 = ValueLayout.JAVA_INT;</info>
+        <info descr="int4">ValueLayout vl0 = ValueLayout.JAVA_INT;</info>
         <info descr="1%int4">ValueLayout vl1 = ValueLayout.JAVA_INT_UNALIGNED;</info>
-        <info descr="1%()0">MemoryLayout ml0 = <info descr="1%()0">MemoryLayout.structLayout()</info>;</info>
-        <info descr="4%(4%int4,4%int4)8">MemoryLayout ml1 = <info descr="4%(4%int4,4%int4)8">MemoryLayout.structLayout(vl0, vl0)</info>;</info>
-        <info descr="4%(4%(4%int4,4%int4)8,1%int4)12">MemoryLayout ml2 = <info descr="4%(4%(4%int4,4%int4)8,1%int4)12">MemoryLayout.structLayout(ml1, vl1)</info>;</info>
+        <info descr="1%[]">MemoryLayout ml0 = <info descr="1%[]">MemoryLayout.structLayout()</info>;</info>
+        <info descr="4%[int4int4]">MemoryLayout ml1 = <info descr="4%[int4int4]">MemoryLayout.structLayout(vl0, vl0)</info>;</info>
+        <info descr="4%[4%[int4int4]1%int4]">MemoryLayout ml2 = <info descr="4%[4%[int4int4]1%int4]">MemoryLayout.structLayout(ml1, vl1)</info>;</info>
     }
 }

--- a/src/test/testData/MethodHandlesTableSwitch.java
+++ b/src/test/testData/MethodHandlesTableSwitch.java
@@ -9,15 +9,15 @@ class MethodHandlesTableSwitch {
         // that works
         <info descr="(int)int">MethodHandle ts1 = <info descr="(int)int">tableSwitch(<info descr="(int)int">identity(int.class)</info>, <info descr="(int)int">identity(int.class)</info>)</info>;</info>
         // no leading int param
-        <info descr="TopMethodHandleType">MethodHandle ts2 = <info descr="TopMethodHandleType">tableSwitch(<info descr="(String)String">identity(String.class)</info>, <info descr="(String)String">identity(String.class)</info>)</info>;</info>
+        <info descr="⊤">MethodHandle ts2 = <info descr="⊤">tableSwitch(<info descr="(String)String">identity(String.class)</info>, <info descr="(String)String">identity(String.class)</info>)</info>;</info>
         // parameter list differs in length
-        <info descr="TopMethodHandleType">MethodHandle ts3 = <info descr="TopMethodHandleType">tableSwitch(<info descr="(int)void">empty(<info descr="(int)void">methodType(void.class, int.class)</info>)</info>, <info descr="(int,String)void">empty(<info descr="(int,String)void">methodType(void.class, int.class, String.class)</info>)</info>)</info>;</info>
+        <info descr="⊤">MethodHandle ts3 = <info descr="⊤">tableSwitch(<info descr="(int)void">empty(<info descr="(int)void">methodType(void.class, int.class)</info>)</info>, <info descr="(int,String)void">empty(<info descr="(int,String)void">methodType(void.class, int.class, String.class)</info>)</info>)</info>;</info>
         // parameter list is empty
-        <info descr="TopMethodHandleType">MethodHandle ts4 = <info descr="TopMethodHandleType">tableSwitch(<info descr="()void">empty(<info descr="()void">methodType(void.class)</info>)</info>, <info descr="()void">empty(<info descr="()void">methodType(void.class)</info>)</info>)</info>;</info>
+        <info descr="⊤">MethodHandle ts4 = <info descr="⊤">tableSwitch(<info descr="()void">empty(<info descr="()void">methodType(void.class)</info>)</info>, <info descr="()void">empty(<info descr="()void">methodType(void.class)</info>)</info>)</info>;</info>
         // parameter list differs in types
-        <info descr="TopMethodHandleType">MethodHandle ts5 = <info descr="TopMethodHandleType">tableSwitch(<info descr="(int,CharSequence)void">empty(<info descr="(int,CharSequence)void">methodType(void.class, int.class, CharSequence.class)</info>)</info>, <info descr="(int,String)void">empty(<info descr="(int,String)void">methodType(void.class, int.class, String.class)</info>)</info>)</info>;</info>
+        <info descr="⊤">MethodHandle ts5 = <info descr="⊤">tableSwitch(<info descr="(int,CharSequence)void">empty(<info descr="(int,CharSequence)void">methodType(void.class, int.class, CharSequence.class)</info>)</info>, <info descr="(int,String)void">empty(<info descr="(int,String)void">methodType(void.class, int.class, String.class)</info>)</info>)</info>;</info>
         // return types differ
-        <info descr="TopMethodHandleType">MethodHandle ts6 = <info descr="TopMethodHandleType">tableSwitch(<info descr="(int)String">empty(<info descr="(int)String">methodType(String.class, int.class)</info>)</info>, <info descr="(int)CharSequence">empty(<info descr="(int)CharSequence">methodType(CharSequence.class, int.class)</info>)</info>)</info>;</info>
+        <info descr="⊤">MethodHandle ts6 = <info descr="⊤">tableSwitch(<info descr="(int)String">empty(<info descr="(int)String">methodType(String.class, int.class)</info>)</info>, <info descr="(int)CharSequence">empty(<info descr="(int)CharSequence">methodType(CharSequence.class, int.class)</info>)</info>)</info>;</info>
         // that works but is more complex
         <info descr="(int,String)int">MethodHandle ts7 = <info descr="(int,String)int">tableSwitch(
                 <info descr="(int,String)int">empty(<info descr="(int,String)int">methodType(int.class, int.class, String.class)</info>)</info>,


### PR DESCRIPTION
We can contribute the types as documentation (i.e. when pressing `Ctrl` + `Q` when having the cursor on a variable name).
This can be helpful for larger types.
It also makes sense to bring all the toString code into one place to make adjustments easier.