### PR TITLE
feature: PaddingLayout support + struct alignment inspections

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/dfa/SsaAnalyzer.kt
@@ -316,6 +316,10 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, val typeData: TypeData) 
                 memoryLayoutHelper.withByteAlignment(qualifier ?: return noMatch(), arguments[0], block)
             }
             "structLayout" -> memoryLayoutHelper.structLayout(arguments, block)
+            "paddingLayout" -> {
+                if (arguments.size != 1) return noMatch()
+                memoryLayoutHelper.paddingLayout(arguments[0])
+            }
 
             else -> noMatch()
         }

--- a/src/main/kotlin/de/sirywell/handlehints/foreign/MemoryLayoutHelper.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/foreign/MemoryLayoutHelper.kt
@@ -1,15 +1,15 @@
 package de.sirywell.handlehints.foreign
 
+import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.psi.PsiExpression
 import de.sirywell.handlehints.MethodHandleBundle.message
 import de.sirywell.handlehints.dfa.SsaAnalyzer
 import de.sirywell.handlehints.dfa.SsaConstruction
 import de.sirywell.handlehints.getConstantOfType
+import de.sirywell.handlehints.inspection.AdjustAlignmentFix
+import de.sirywell.handlehints.inspection.AdjustPaddingFix
 import de.sirywell.handlehints.inspection.ProblemEmitter
-import de.sirywell.handlehints.type.CompleteMemoryLayoutList
-import de.sirywell.handlehints.type.MemoryLayoutType
-import de.sirywell.handlehints.type.StructLayoutType
-import de.sirywell.handlehints.type.TopMemoryLayoutType
+import de.sirywell.handlehints.type.*
 
 class MemoryLayoutHelper(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(ssaAnalyzer.typeData) {
 
@@ -18,9 +18,7 @@ class MemoryLayoutHelper(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(
         byteAlignmentExpr: PsiExpression,
         block: SsaConstruction.Block
     ): MemoryLayoutType {
-        val byteAlignment = (byteAlignmentExpr.getConstantOfType<Int>()
-            ?: byteAlignmentExpr.getConstantOfType<Long>()
-            ?: return TopMemoryLayoutType).toLong()
+        val byteAlignment = byteAlignmentExpr.asLong() ?: return TopMemoryLayoutType
         if (byteAlignment < 0 || byteAlignment.countOneBits() != 1) {
             return emitProblem(byteAlignmentExpr, message("problem.general.argument.notAPowerOfTwo", byteAlignment))
         }
@@ -28,11 +26,41 @@ class MemoryLayoutHelper(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(
         return target.withByteAlignment(byteAlignment)
     }
 
+    private fun PsiExpression.asLong(): Long? {
+        return (getConstantOfType<Int>()
+            ?: getConstantOfType<Long>())?.toLong()
+    }
+
     fun structLayout(arguments: List<PsiExpression>, block: SsaConstruction.Block): MemoryLayoutType {
         val members = arguments.map { ssaAnalyzer.memoryLayoutType(it, block) ?: TopMemoryLayoutType }
         val size = sumSize(members)
         val alignment = maxAlignment(members)
+        if (size != null) {
+            var t = 0L
+            members.forEachIndexed { index, type ->
+                val byteAlignment = type.byteAlignment
+                if (byteAlignment != null && t % byteAlignment != 0L) {
+                    return emitProblem(
+                        arguments[index], message(
+                            "problem.foreign.memory.layoutMismatch",
+                            byteAlignment, t
+                        ),
+                        LocalQuickFix.from(AdjustPaddingFix(arguments[index],  type.byteSize!! - t % byteAlignment))!!,
+                        LocalQuickFix.from(AdjustAlignmentFix(arguments[index], t % byteAlignment))!!
+                    )
+                }
+                t += type.byteSize!! // size is not null, so all elements have non-null byteSize
+            }
+        }
         return StructLayoutType(CompleteMemoryLayoutList(members), alignment, size)
+    }
+
+    fun paddingLayout(byteSizeExpr: PsiExpression): MemoryLayoutType {
+        val size = byteSizeExpr.asLong() ?: return PaddingLayoutType(1, null)
+        if (size <= 0) {
+            return emitProblem(byteSizeExpr, message("problem.general.argument.numericConditionMismatch", "> 0", size))
+        }
+        return PaddingLayoutType(1, size)
     }
 
     private fun sumSize(list: List<MemoryLayoutType>): Long? {

--- a/src/main/kotlin/de/sirywell/handlehints/inspection/AdjustAlignmentFix.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/inspection/AdjustAlignmentFix.kt
@@ -1,0 +1,38 @@
+package de.sirywell.handlehints.inspection
+
+import com.intellij.modcommand.ActionContext
+import com.intellij.modcommand.ModPsiUpdater
+import com.intellij.modcommand.PsiUpdateModCommandAction
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiMethodCallExpression
+import com.siyeh.ig.PsiReplacementUtil
+import com.siyeh.ig.psiutils.CommentTracker
+import de.sirywell.handlehints.MethodHandleBundle
+import de.sirywell.handlehints.methodName
+
+class AdjustAlignmentFix(expression: PsiExpression, private val requiredAlignment: Long) :
+    PsiUpdateModCommandAction<PsiExpression>(expression) {
+    override fun getFamilyName(): String {
+        return MethodHandleBundle.message("problem.foreign.memory.layoutMismatch.adjustAlignment")
+    }
+
+    override fun invoke(context: ActionContext, element: PsiExpression, updater: ModPsiUpdater) {
+        val commentTracker = CommentTracker()
+        if (element is PsiMethodCallExpression
+            && element.methodName == "withByteAlignment"
+            && element.argumentList.expressionCount == 1
+        ) {
+            PsiReplacementUtil.replaceExpression(
+                element.argumentList.expressions.first(),
+                "$requiredAlignment",
+                commentTracker
+            )
+            return
+        }
+        PsiReplacementUtil.replaceExpression(
+            element,
+            "${commentTracker.text(element)}.withByteAlignment($requiredAlignment)",
+            commentTracker
+        )
+    }
+}

--- a/src/main/kotlin/de/sirywell/handlehints/inspection/AdjustAlignmentFix.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/inspection/AdjustAlignmentFix.kt
@@ -10,6 +10,7 @@ import com.siyeh.ig.psiutils.CommentTracker
 import de.sirywell.handlehints.MethodHandleBundle
 import de.sirywell.handlehints.methodName
 
+@Suppress("UnstableApiUsage")
 class AdjustAlignmentFix(expression: PsiExpression, private val requiredAlignment: Long) :
     PsiUpdateModCommandAction<PsiExpression>(expression) {
     override fun getFamilyName(): String {

--- a/src/main/kotlin/de/sirywell/handlehints/inspection/AdjustPaddingFix.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/inspection/AdjustPaddingFix.kt
@@ -11,6 +11,7 @@ import com.intellij.psi.util.parentOfType
 import com.siyeh.ig.PsiReplacementUtil
 import com.siyeh.ig.psiutils.CommentTracker
 import de.sirywell.handlehints.MethodHandleBundle
+import de.sirywell.handlehints.getConstantLong
 import de.sirywell.handlehints.methodName
 
 @Suppress("UnstableApiUsage")
@@ -28,7 +29,16 @@ class AdjustPaddingFix(expression: PsiExpression, private val requiredPadding: L
                 val call = arguments.expressions[index - 1] as PsiMethodCallExpression
                 val arg = call.argumentList.expressions[0]
                 val commentTracker = CommentTracker()
-                PsiReplacementUtil.replaceExpression(arg, "$requiredPadding", commentTracker)
+                val c = arg.getConstantLong()
+                if (c != null) {
+                    PsiReplacementUtil.replaceExpression(arg, "${c + requiredPadding}", commentTracker)
+                } else {
+                    PsiReplacementUtil.replaceExpression(
+                        arg,
+                        "${commentTracker.text(arg)} + $requiredPadding",
+                        commentTracker
+                    )
+                }
                 return
             }
         }

--- a/src/main/kotlin/de/sirywell/handlehints/inspection/AdjustPaddingFix.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/inspection/AdjustPaddingFix.kt
@@ -1,0 +1,48 @@
+package de.sirywell.handlehints.inspection
+
+import com.intellij.modcommand.ActionContext
+import com.intellij.modcommand.ModPsiUpdater
+import com.intellij.modcommand.PsiUpdateModCommandAction
+import com.intellij.psi.PsiElementFactory
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiExpressionList
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.util.parentOfType
+import com.siyeh.ig.PsiReplacementUtil
+import com.siyeh.ig.psiutils.CommentTracker
+import de.sirywell.handlehints.MethodHandleBundle
+import de.sirywell.handlehints.methodName
+
+@Suppress("UnstableApiUsage")
+class AdjustPaddingFix(expression: PsiExpression, private val requiredPadding: Long) :
+    PsiUpdateModCommandAction<PsiExpression>(expression) {
+    override fun getFamilyName(): String {
+        return MethodHandleBundle.message("problem.foreign.memory.layoutMismatch.adjustPadding")
+    }
+
+    override fun invoke(context: ActionContext, element: PsiExpression, updater: ModPsiUpdater) {
+        val arguments = element.parentOfType<PsiExpressionList>() ?: return
+        if (arguments.expressionCount > 1) {
+            val index = arguments.expressions.indexOf(element)
+            if (index > 0 && isPaddingLayoutCall(arguments.expressions[index - 1])) {
+                val call = arguments.expressions[index - 1] as PsiMethodCallExpression
+                val arg = call.argumentList.expressions[0]
+                val commentTracker = CommentTracker()
+                PsiReplacementUtil.replaceExpression(arg, "$requiredPadding", commentTracker)
+                return
+            }
+        }
+        val elementFactory = PsiElementFactory.getInstance(context.project)
+        val paddingExpression = elementFactory.createExpressionFromText(
+            "java.lang.foreign.MemoryLayout.paddingLayout($requiredPadding)",
+            element
+        )
+        arguments.addBefore(paddingExpression, element)
+    }
+
+    private fun isPaddingLayoutCall(expression: PsiExpression): Boolean {
+        return expression is PsiMethodCallExpression
+                && expression.methodName == "paddingLayout"
+                && expression.argumentList.expressionCount == 1
+    }
+}

--- a/src/main/kotlin/de/sirywell/handlehints/inspection/ProblemEmitter.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/inspection/ProblemEmitter.kt
@@ -1,5 +1,6 @@
 package de.sirywell.handlehints.inspection
 
+import com.intellij.codeInspection.LocalQuickFix
 import com.intellij.codeInspection.ProblemHighlightType
 import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiExpression
@@ -14,6 +15,17 @@ abstract class ProblemEmitter(protected val typeData: TypeData) {
     protected inline fun <reified T : TypeLatticeElement<T>> emitProblem(element: PsiElement, message: @Nls String): T {
         typeData.reportProblem(element) {
             it.registerProblem(element, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING)
+        }
+        return topForType<T>()
+    }
+
+    protected inline fun <reified T : TypeLatticeElement<T>> emitProblem(
+        element: PsiElement,
+        message: @Nls String,
+        vararg quickFixes: LocalQuickFix
+    ): T {
+        typeData.reportProblem(element) {
+            it.registerProblem(element, message, ProblemHighlightType.GENERIC_ERROR_OR_WARNING, *quickFixes)
         }
         return topForType<T>()
     }

--- a/src/main/kotlin/de/sirywell/handlehints/presentation/TypePrinter.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/presentation/TypePrinter.kt
@@ -104,6 +104,10 @@ class TypePrinter : TypeVisitor<StringBuilder, Unit> {
         type.memberLayouts.accept(this, context)
     }
 
+    override fun visit(type: PaddingLayoutType, context: StringBuilder) {
+        context.append("x").append(type.byteSize ?: "?")
+    }
+
     override fun visit(type: TopMemoryLayoutList, context: StringBuilder) {
         context.append("[{⊤}]")
     }

--- a/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
@@ -113,6 +113,12 @@ inline fun <reified T> PsiExpression.getConstantOfType(): T? {
         ?.getConstantOfType(T::class.java)
 }
 
+fun PsiExpression.getConstantLong(): Long? {
+    return (getConstantOfType<Int>()
+        ?: getConstantOfType<Long>())?.toLong()
+}
+
+
 fun Collection<PsiExpression>.mapToTypes(): List<Type> {
     return this.map { element -> element.asType() }
 }

--- a/src/main/kotlin/de/sirywell/handlehints/type/TypeVisitor.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/TypeVisitor.kt
@@ -19,6 +19,7 @@ interface TypeVisitor<C, R> {
     fun visit(type: TopMemoryLayoutType, context: C): R
     fun visit(type: ValueLayoutType, context: C): R
     fun visit(type: StructLayoutType, context: C): R
+    fun visit(type: PaddingLayoutType, context: C): R
     fun visit(type: TopMemoryLayoutList, context: C): R
     fun visit(type: BotMemoryLayoutList, context: C): R
     fun visit(type: CompleteMemoryLayoutList, context: C): R

--- a/src/main/resources/messages/MethodHandleMessages.properties
+++ b/src/main/resources/messages/MethodHandleMessages.properties
@@ -34,3 +34,7 @@ problem.merging.tableSwitch.leadingInt=The passed MethodHandle requires a leadin
 problem.merging.tableSwitch.notIdentical=The passed MethodHandle type is not compatible with the previous handle(s).
 problem.invocation.returnType.mustBeVoid=MethodHandle returns void but is called in a non-void context.
 problem.general.argument.notAPowerOfTwo=Argument must be a power of 2 but was {0}.
+problem.general.argument.numericConditionMismatch=Argument must be {0} but is {1}.
+problem.foreign.memory.layoutMismatch=Layout requires a byte alignment of {0} but is inserted at an offset of {1}.
+problem.foreign.memory.layoutMismatch.adjustPadding=Adjust the padding before this layout
+problem.foreign.memory.layoutMismatch.adjustAlignment=Adjust the alignment of this layout

--- a/src/test/kotlin/de/sirywell/handlehints/mhtype/MemoryLayoutTypeTest.kt
+++ b/src/test/kotlin/de/sirywell/handlehints/mhtype/MemoryLayoutTypeTest.kt
@@ -5,4 +5,9 @@ class MemoryLayoutTypeTest : TypeAnalysisTestBase() {
     fun testMemoryLayoutWithByteAlignment() = doTypeCheckingTest()
 
     fun testMemoryLayoutStructLayout() = doTypeCheckingTest()
+
+    fun testMemoryLayoutPaddingLayout() = doTypeCheckingTest()
+
+
+    fun testMemoryLayoutStructLayoutInspection() = doInspectionTest()
 }

--- a/src/test/testData/MemoryLayoutPaddingLayout.java
+++ b/src/test/testData/MemoryLayoutPaddingLayout.java
@@ -1,0 +1,11 @@
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.PaddingLayout;
+
+class MemoryLayoutPaddingLayout {
+    void m() {
+        <info descr="x1">PaddingLayout pl0 = <info descr="x1">MemoryLayout.paddingLayout(1)</info>;</info>
+        <info descr="x10">PaddingLayout pl1 = <info descr="x10">MemoryLayout.paddingLayout(10L)</info>;</info>
+        <info descr="⊤">PaddingLayout pl2 = <info descr="⊤">MemoryLayout.paddingLayout(-10L)</info>;</info>
+        <info descr="⊤">PaddingLayout pl3 = <info descr="⊤">MemoryLayout.paddingLayout(0L)</info>;</info>
+    }
+}

--- a/src/test/testData/MemoryLayoutStructLayoutInspection.java
+++ b/src/test/testData/MemoryLayoutStructLayoutInspection.java
@@ -1,0 +1,19 @@
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.PaddingLayout;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.ValueLayout;
+
+class MemoryLayoutStructLayoutInspection {
+    void m() {
+        ValueLayout vl0 = ValueLayout.JAVA_SHORT;
+        PaddingLayout pl0 = MemoryLayout.paddingLayout(6);
+        ValueLayout vl1 = ValueLayout.JAVA_LONG;
+        // invalid, padding needed for vl1
+        StructLayout sl0 = MemoryLayout.structLayout(vl0, <warning descr="Layout requires a byte alignment of 8 but is inserted at an offset of 2.">vl1</warning>);
+        StructLayout sl1 = MemoryLayout.structLayout(vl0, <warning descr="Layout requires a byte alignment of 4 but is inserted at an offset of 2.">vl1.withByteAlignment(4)</warning>);
+        StructLayout sl2 = MemoryLayout.structLayout(vl0, MemoryLayout.paddingLayout(1), <warning descr="Layout requires a byte alignment of 8 but is inserted at an offset of 3.">vl1</warning>);
+        // valid, proper padding
+        StructLayout sl3 = MemoryLayout.structLayout(vl0, pl0, vl1);
+        StructLayout sl4 = MemoryLayout.structLayout(vl0, vl1.withByteAlignment(1));
+    }
+}


### PR DESCRIPTION
By introducing `PaddingLayout` support, it also makes sense to add inspections to adjust padding or alignment for a misconfigured `StructLayout`.