### PR TITLE
feature: warning on withByteAlignment on struct

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/type/TypeLatticeElementList.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/TypeLatticeElementList.kt
@@ -40,6 +40,8 @@ sealed interface TypeLatticeElementList<T : TypeLatticeElement<T>> : TypeLattice
 
     fun sizeOrNull(): Int?
 
+    fun anyKnownMatches(predicate: (T) -> Boolean): Boolean
+
     fun topList(): TopTypeLatticeElementList<T>
     fun botList(): BotTypeLatticeElementList<T>
     fun top(): T
@@ -70,6 +72,8 @@ abstract class BotTypeLatticeElementList<T : TypeLatticeElement<T>> : TypeLattic
     }
 
     override fun sizeOrNull() = null
+
+    override fun anyKnownMatches(predicate: (T) -> Boolean) = false
 }
 
 abstract class TopTypeLatticeElementList<T : TypeLatticeElement<T>> : TypeLatticeElementList<T> {
@@ -87,6 +91,8 @@ abstract class TopTypeLatticeElementList<T : TypeLatticeElement<T>> : TypeLattic
     }
 
     override fun sizeOrNull() = null
+
+    override fun anyKnownMatches(predicate: (T) -> Boolean) = false
 }
 
 abstract class CompleteTypeLatticeElementList<T : TypeLatticeElement<T>>(val typeList: List<T>) : TypeLatticeElementList<T> {
@@ -171,6 +177,8 @@ abstract class CompleteTypeLatticeElementList<T : TypeLatticeElement<T>>(val typ
     override fun compareSize(value: Int) = size.compareTo(value).order()
 
     override fun sizeOrNull() = size
+
+    override fun anyKnownMatches(predicate: (T) -> Boolean) = typeList.any(predicate)
 }
 
 abstract class IncompleteTypeLatticeElementList<T : TypeLatticeElement<T>>(val knownTypes: SortedMap<Int, T>) : TypeLatticeElementList<T> {
@@ -247,6 +255,8 @@ abstract class IncompleteTypeLatticeElementList<T : TypeLatticeElement<T>>(val k
     }
 
     override fun sizeOrNull() = null
+
+    override fun anyKnownMatches(predicate: (T) -> Boolean) = knownTypes.values.any(predicate)
 }
 
 private fun <T : TypeLatticeElement<T>> TypeLatticeElementList<T>.toMap(): SortedMap<Int, T> {

--- a/src/main/resources/messages/MethodHandleMessages.properties
+++ b/src/main/resources/messages/MethodHandleMessages.properties
@@ -38,3 +38,4 @@ problem.general.argument.numericConditionMismatch=Argument must be {0} but is {1
 problem.foreign.memory.layoutMismatch=Layout requires a byte alignment of {0} but is inserted at an offset of {1}.
 problem.foreign.memory.layoutMismatch.adjustPadding=Adjust the padding before this layout
 problem.foreign.memory.layoutMismatch.adjustAlignment=Adjust the alignment of this layout
+problem.foreign.memory.invalidAlignment=This layout cannot be {0} byte aligned due to one of its member layouts.

--- a/src/test/testData/MemoryLayoutStructLayoutInspection.java
+++ b/src/test/testData/MemoryLayoutStructLayoutInspection.java
@@ -15,5 +15,10 @@ class MemoryLayoutStructLayoutInspection {
         // valid, proper padding
         StructLayout sl3 = MemoryLayout.structLayout(vl0, pl0, vl1);
         StructLayout sl4 = MemoryLayout.structLayout(vl0, vl1.withByteAlignment(1));
+        // structs typically have an alignment < byteSize
+        // withByteAlignment will fail if smaller than the largest alignment of member
+        StructLayout sl5 = MemoryLayout.structLayout(ValueLayout.JAVA_LONG, ValueLayout.JAVA_INT);
+        StructLayout sl6 = MemoryLayout.structLayout(sl5, <warning descr="Layout requires a byte alignment of 8 but is inserted at an offset of 12.">sl5</warning>);
+        StructLayout sl7 = MemoryLayout.structLayout(sl5, sl5.withByteAlignment(<warning descr="This layout cannot be 4 byte aligned due to one of its member layouts.">4</warning>));
     }
 }


### PR DESCRIPTION
`withByteAlignment` on a struct depends on the alignments of its member layouts. Alignments smaller than the maximum alignment are disallowed. We should not provide the `withByteAlignment` quick fix in such cases, and also warn in case of wrong code.