### PR TITLE
fix: make documentation target provider more precise

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/dfa/SsaAnalyzer.kt
@@ -117,20 +117,6 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, val typeData: TypeData) 
         }
     }
 
-    /**
-     * Returns true if the variable type has no [MethodHandleType]
-     */
-    private fun isUnrelated(variable: PsiVariable): Boolean {
-        return isUnrelated(variable.type, variable)
-    }
-
-    private fun isUnrelated(type: PsiType, context: PsiElement): Boolean {
-        return type != methodTypeType(context)
-                && type != methodHandleType(context)
-                && type != varHandleType(context)
-                && type !in memoryLayoutTypes(context)
-    }
-
     fun resolveType(expression: PsiExpression, block: Block): TypeLatticeElement<*>? {
         if (expression.type == null || isUnrelated(expression.type!!, expression)) {
             return noMatch() // unrelated

--- a/src/main/kotlin/de/sirywell/handlehints/presentation/TypeDocumentationTargetProvider.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/presentation/TypeDocumentationTargetProvider.kt
@@ -6,11 +6,15 @@ import com.intellij.psi.PsiElement
 import com.intellij.psi.PsiIdentifier
 import com.intellij.psi.PsiReferenceExpression
 import com.intellij.psi.PsiVariable
+import de.sirywell.handlehints.isUnrelated
 
 class TypeDocumentationTargetProvider : PsiDocumentationTargetProvider {
 
     override fun documentationTarget(element: PsiElement, originalElement: PsiElement?): DocumentationTarget? {
-        if (originalElement is PsiIdentifier && isVariableName(originalElement)) {
+        if (element is PsiVariable
+            && element.containingFile == originalElement?.containingFile
+            && !isUnrelated(element)
+            && originalElement is PsiIdentifier && isVariableName(originalElement)) {
             return TypeDocumentationTarget(originalElement, element)
         }
         return null

--- a/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
@@ -153,3 +153,17 @@ fun matches(method: PsiMethod, returnType: ExactType, parameterList: CompleteTyp
         .map { if (it.type is PsiEllipsisType) (it.type as PsiEllipsisType).toArrayType() else it.type }
         .foldIndexed(true) { index, acc, param -> acc && ps[index] == param }
 }
+
+/**
+ * Returns true if the variable type has no [MethodHandleType]
+ */
+fun isUnrelated(variable: PsiVariable): Boolean {
+    return isUnrelated(variable.type, variable)
+}
+
+fun isUnrelated(type: PsiType, context: PsiElement): Boolean {
+    return type != methodTypeType(context)
+            && type != methodHandleType(context)
+            && type != varHandleType(context)
+            && type !in memoryLayoutTypes(context)
+}


### PR DESCRIPTION
The checks were not precise enough, resulting in missing documentation for methods and unrelated variables.