### PR TITLE
feature: add support for `PathElements` and `varHandle()`

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/foreign/MemoryLayoutHelper.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/foreign/MemoryLayoutHelper.kt
@@ -2,6 +2,8 @@ package de.sirywell.handlehints.foreign
 
 import com.intellij.codeInspection.LocalQuickFix.from
 import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiType
+import com.intellij.util.containers.headTail
 import de.sirywell.handlehints.MethodHandleBundle.message
 import de.sirywell.handlehints.dfa.SsaAnalyzer
 import de.sirywell.handlehints.dfa.SsaConstruction
@@ -156,5 +158,169 @@ class MemoryLayoutHelper(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(
         return list
             .map { it.byteAlignment ?: return null }
             .maxOrNull() ?: 1 // if empty, the alignment is 1
+    }
+
+    fun varHandle(
+        qualifier: PsiExpression,
+        arguments: List<PsiExpression>,
+        methodExpr: PsiExpression,
+        block: SsaConstruction.Block
+    ): VarHandleType {
+        val layoutType = ssaAnalyzer.memoryLayoutType(qualifier, block) ?: TopMemoryLayoutType
+        val path = toPath(arguments, block)
+        val memorySegmentType =
+            PsiType.getTypeByName("java.lang.foreign.MemorySegment", qualifier.project, qualifier.resolveScope)
+        return resolvePath(path, layoutType, mutableListOf(ExactType(memorySegmentType))) {
+            if (it == -1) methodExpr
+            else arguments[it]
+        }
+    }
+
+    private tailrec fun resolvePath(
+        path: List<IndexedValue<PathElementType>>,
+        layoutType: MemoryLayoutType,
+        coords: MutableList<Type>,
+        contextElement: (Int) -> PsiExpression
+    ): VarHandleType {
+        if (layoutType == BotMemoryLayoutType) return BotVarHandleType
+        else if (layoutType == TopMemoryLayoutType) return TopVarHandleType
+        if (path.isEmpty()) {
+            return when (layoutType) {
+                is ValueLayoutType -> CompleteVarHandleType(layoutType.type, CompleteTypeList(coords))
+                else -> emitProblem(contextElement(-1), message("problem.foreign.memory.pathTargetNotValueLayout"))
+            }
+        }
+        val (head, tail) = path.headTail()
+        val resolvedLayout = when (head.value) {
+            BotPathElementType -> return BotVarHandleType // TODO does that make sense?
+            TopPathElementType -> return TopVarHandleType
+            is SequenceElementType -> sequenceElement(
+                layoutType,
+                // what is wrong with the Kotlin type system?
+                IndexedValue(head.index, head.value as SequenceElementType),
+                coords,
+                contextElement
+            )
+
+            is GroupElementType -> groupElement(
+                layoutType,
+                IndexedValue(head.index, head.value as GroupElementType),
+                contextElement
+            )
+        }
+        return resolvePath(tail, resolvedLayout, coords, contextElement)
+    }
+
+    private fun groupElement(
+        layoutType: MemoryLayoutType,
+        head: IndexedValue<GroupElementType>,
+        contextElement: (Int) -> PsiExpression
+    ): MemoryLayoutType {
+        return when (layoutType) {
+            BotMemoryLayoutType -> return BotMemoryLayoutType
+            TopMemoryLayoutType -> return TopMemoryLayoutType
+            is StructLayoutType -> findByElementType(head, layoutType.memberLayouts, contextElement)
+            is UnionLayoutType -> findByElementType(head, layoutType.memberLayouts, contextElement)
+            is SequenceLayoutType,
+            is PaddingLayoutType,
+            is ValueLayoutType -> {
+                return emitProblem(
+                    contextElement(head.index),
+                    message(
+                        "problem.foreign.memory.pathElementMismatch",
+                        "group",
+                        layoutType::class.simpleName!!.replace("Type", "")
+                    )
+                )
+            }
+        }
+    }
+
+    private fun findByElementType(
+        elementType: IndexedValue<GroupElementType>,
+        memberLayouts: MemoryLayoutList,
+        contextElement: (Int) -> PsiExpression
+    ): MemoryLayoutType {
+        return when (elementType.value.variant) {
+            is IndexGroupElementVariant -> {
+                val index = (elementType.value.variant as IndexGroupElementVariant).index
+                if (index == null || index >= Int.MAX_VALUE) TopMemoryLayoutType
+                else if (memberLayouts.compareSize((index + 1).toInt()) == PartialOrder.LT) {
+                    // known index out of bounds
+                    emitProblem(
+                        contextElement(elementType.index),
+                        message("problem.foreign.memory.pathGroupElementOutOfBounds", 0, index, memberLayouts.sizeOrNull()!!)
+                    )
+                } else memberLayouts[index.toInt()]
+            }
+
+            is NameGroupElementVariant -> {
+                val name = (elementType.value.variant as NameGroupElementVariant).name
+                if (name == null) TopMemoryLayoutType
+                // we need to be conservative here: multiple memberLayouts can have the same name
+                // so we must abort as soon as we find a layout with an unknown name
+                else {
+                    for (type in memberLayouts.partialList()) {
+                        if (type.name !is ExactLayoutName) return TopMemoryLayoutType
+                        else if ((type.name as ExactLayoutName).name == name) return type
+
+                    }
+                    return emitProblem(
+                        contextElement(elementType.index),
+                        message("problem.foreign.memory.pathGroupElementUnknownName", name)
+                    )
+                }
+            }
+        }
+    }
+
+    private fun sequenceElement(
+        layoutType: MemoryLayoutType,
+        head: IndexedValue<SequenceElementType>,
+        coords: MutableList<Type>,
+        contextElement: (Int) -> PsiExpression
+    ): MemoryLayoutType {
+        val inner = when (layoutType) {
+            BotMemoryLayoutType -> return BotMemoryLayoutType
+            TopMemoryLayoutType -> return TopMemoryLayoutType
+            is SequenceLayoutType -> layoutType.elementLayout
+            is PaddingLayoutType,
+            is StructLayoutType,
+            is UnionLayoutType,
+            is ValueLayoutType -> {
+                return emitProblem(
+                    contextElement(head.index),
+                    message(
+                        "problem.foreign.memory.pathElementMismatch",
+                        "sequence",
+                        layoutType::class.simpleName!!.replace("Type", "")
+                    )
+                )
+            }
+        }
+        val headVal = head.value
+        when (headVal.variant) {
+            OpenSequenceElementVariant -> coords.add(ExactType.longType)
+            is SelectingOpenSequenceElementVariant -> coords.add(ExactType.longType)
+            is SelectingSequenceElementVariant -> {
+                headVal.variant.index?.let {
+                    val c = layoutType.elementCount ?: Long.MAX_VALUE
+                    if (it > c) {
+                        return emitOutOfBounds(layoutType.elementCount, contextElement(head.index), it, true)
+                    }
+                }
+            }
+        }
+        return inner
+    }
+
+    private fun toPath(
+        arguments: List<PsiExpression>,
+        block: SsaConstruction.Block
+    ): List<IndexedValue<PathElementType>> {
+        return arguments
+            .map { ssaAnalyzer.pathElementType(it, block) ?: TopPathElementType }
+            .withIndex()
+            .toList()
     }
 }

--- a/src/main/kotlin/de/sirywell/handlehints/foreign/PathElementHelper.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/foreign/PathElementHelper.kt
@@ -1,0 +1,63 @@
+package de.sirywell.handlehints.foreign
+
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiTypes
+import de.sirywell.handlehints.MethodHandleBundle.message
+import de.sirywell.handlehints.dfa.SsaAnalyzer
+import de.sirywell.handlehints.getConstantLong
+import de.sirywell.handlehints.getConstantOfType
+import de.sirywell.handlehints.inspection.ProblemEmitter
+import de.sirywell.handlehints.type.*
+
+class PathElementHelper(ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(ssaAnalyzer.typeData) {
+
+    fun sequenceElement(): PathElementType {
+        return SequenceElementType(OpenSequenceElementVariant)
+    }
+    fun sequenceElement(indexExpr: PsiExpression): PathElementType {
+        val index = indexExpr.getConstantLong()
+        if ((index ?: Long.MAX_VALUE) < 0L) {
+            return emitProblem(
+                indexExpr,
+                message("problem.general.argument.numericConditionMismatch", ">= 0", index!!)
+            )
+        }
+        return SequenceElementType(SelectingSequenceElementVariant(index))
+    }
+
+    fun sequenceElement(startExpr: PsiExpression, stepExpr: PsiExpression): PathElementType {
+        val start = startExpr.getConstantLong()
+        val step = stepExpr.getConstantLong()
+        if ((start ?: Long.MAX_VALUE) < 0L) {
+            return emitProblem(
+                startExpr,
+                message("problem.general.argument.numericConditionMismatch", ">= 0", start!!)
+            )
+        }
+        if ((step ?: 1L) == 0L) {
+            return emitProblem(
+                stepExpr,
+                message("problem.general.argument.numericConditionMismatch", "!= 0", step!!)
+            )
+        }
+        return SequenceElementType(SelectingOpenSequenceElementVariant(start, step))
+    }
+
+    fun groupElement(indexOrNameExpr: PsiExpression): PathElementType {
+        if (indexOrNameExpr.type?.canonicalText == "java.lang.String") {
+            return GroupElementType(NameGroupElementVariant(indexOrNameExpr.getConstantOfType()))
+        }
+        if (indexOrNameExpr.type in setOf(PsiTypes.longType(), PsiTypes.intType())) {
+            val index = indexOrNameExpr.getConstantLong()
+            if (index != null && index < 0) {
+                return emitProblem(
+                    indexOrNameExpr,
+                    message("problem.general.argument.numericConditionMismatch", ">= 0", index)
+                )
+
+            }
+            return GroupElementType(IndexGroupElementVariant(index))
+        }
+        return TopPathElementType
+    }
+}

--- a/src/main/kotlin/de/sirywell/handlehints/inspection/ProblemEmitter.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/inspection/ProblemEmitter.kt
@@ -76,9 +76,9 @@ abstract class ProblemEmitter(protected val typeData: TypeData) {
     }
 
     protected inline fun <reified T : TypeLatticeElement<T>> emitOutOfBounds(
-        size: Int?,
+        size: Long?,
         targetExpr: PsiExpression,
-        pos: Int,
+        pos: Long,
         exclusive: Boolean
     ): T = if (size != null) {
         if (exclusive) {

--- a/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandlesMerger.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/mhtype/MethodHandlesMerger.kt
@@ -226,7 +226,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
         val target = ssaAnalyzer.methodHandleType(targetExpr, block) ?: bottomType
         val signature = target
         if (signature.parameterTypes.compareSize(pos) == PartialOrder.LT) {
-            return emitOutOfBounds(signature.parameterTypes.sizeOrNull(), targetExpr, pos, false)
+            return emitOutOfBounds(signature.parameterTypes.sizeOrNull()?.toLong(), targetExpr, pos.toLong(), false)
         }
         val list = signature.parameterTypes.addAllAt(pos, CompleteTypeList(types))
         return signature.withParameterTypes(list)
@@ -368,7 +368,7 @@ class MethodHandlesMerger(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter
             if (expr != null) {
                 return emitProblem(expr, message("problem.general.position.invalidIndexOffset", valueTypesIndex + pos))
             }
-            return emitOutOfBounds(parameterList.sizeOrNull(), posExpr, pos, false)
+            return emitOutOfBounds(parameterList.sizeOrNull()?.toLong(), posExpr, pos.toLong(), false)
         }
         val new = parameterList.removeAt(pos, valueTypes.size)
         return target.withParameterTypes(new)

--- a/src/main/kotlin/de/sirywell/handlehints/presentation/TypePrinter.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/presentation/TypePrinter.kt
@@ -189,4 +189,59 @@ class TypePrinter : TypeVisitor<TypePrinter.PrintContext, Unit> {
         context.append("({⊥})")
     }
 
+    override fun visit(type: SequenceElementType, context: PrintContext) {
+        when (type.variant) {
+            OpenSequenceElementVariant -> context.append("sequenceElement()")
+            is SelectingOpenSequenceElementVariant -> context.append("sequenceElement(")
+                .append((type.variant.start ?: "?").toString())
+                .append(", ")
+                .append((type.variant.step ?: "?").toString())
+                .append(")")
+            is SelectingSequenceElementVariant -> context.append("sequenceElement(")
+                .append((type.variant.index ?: "?").toString())
+                .append(")")
+        }
+    }
+
+    override fun visit(type: TopPathElementType, context: PrintContext) {
+        context.append("{⊤}")
+    }
+
+    override fun visit(type: BotPathElementType, context: PrintContext) {
+        context.append("{⊥}")
+    }
+
+    override fun visit(type: TopPathElementList, context: PrintContext) {
+        context.append("{⊤...}")
+    }
+
+    override fun visit(type: BotPathElementList, context: PrintContext) {
+        context.append("{⊥...}")
+    }
+
+    override fun visit(type: CompletePathElementList, context: PrintContext) {
+        context.append(type.typeList.joinToString(separator = "->"))
+    }
+
+    override fun visit(type: IncompletePathElementList, context: PrintContext) {
+        (0..type.knownTypes.lastKey()).map {
+            type.parameterType(it).accept(this, context)
+            context.append("->")
+        }
+        context.append("...")
+    }
+
+    override fun visit(type: GroupElementType, context: PrintContext) {
+        when (type.variant) {
+            is IndexGroupElementVariant -> context.append("groupElement(")
+                .append((type.variant.index ?: "index?").toString())
+                .append(")")
+
+            is NameGroupElementVariant -> context.append("groupElement(")
+                .append((type.variant.name ?: "name?").toString())
+                .append(")")
+
+        }
+    }
+
 }

--- a/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
@@ -36,6 +36,10 @@ fun receiverIsMemoryLayout(element: PsiMethodCallExpression): Boolean {
     return superType.isAssignableFrom(actual)
 }
 
+fun receiverIsPathElement(element: PsiMethodCallExpression): Boolean {
+    return element.resolveMethod()?.containingClass?.qualifiedName == "java.lang.foreign.MemoryLayout.PathElement"
+}
+
 fun methodHandleType(element: PsiElement): PsiClassType {
     return PsiType.getTypeByName("java.lang.invoke.MethodHandle", element.project, element.resolveScope)
 }
@@ -46,6 +50,10 @@ fun varHandleType(element: PsiElement): PsiClassType {
 
 fun methodTypeType(element: PsiElement): PsiClassType {
     return PsiType.getTypeByName("java.lang.invoke.MethodType", element.project, element.resolveScope)
+}
+
+fun pathElementType(element: PsiElement): PsiClassType {
+    return PsiType.getTypeByName("java.lang.foreign.MemoryLayout.PathElement", element.project, element.resolveScope)
 }
 
 fun objectType(element: PsiElement): PsiType {
@@ -165,5 +173,6 @@ fun isUnrelated(type: PsiType, context: PsiElement): Boolean {
     return type != methodTypeType(context)
             && type != methodHandleType(context)
             && type != varHandleType(context)
+            && type != pathElementType(context)
             && type !in memoryLayoutTypes(context)
 }

--- a/src/main/kotlin/de/sirywell/handlehints/type/MethodHandleType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/MethodHandleType.kt
@@ -2,8 +2,8 @@ package de.sirywell.handlehints.type
 
 import de.sirywell.handlehints.TriState
 
+@TypeInfo(TopMethodHandleType::class)
 sealed interface MethodHandleType : TypeLatticeElement<MethodHandleType> {
-
 
     fun withReturnType(returnType: Type): MethodHandleType
 

--- a/src/main/kotlin/de/sirywell/handlehints/type/Type.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/Type.kt
@@ -10,6 +10,7 @@ import de.sirywell.handlehints.objectType
 import de.sirywell.handlehints.toTriState
 import java.util.*
 
+@TypeInfo(TopType::class)
 sealed interface Type : TypeLatticeElement<Type> {
 
     fun erase(manager: PsiManager, scope: GlobalSearchScope): Type
@@ -21,16 +22,16 @@ sealed interface Type : TypeLatticeElement<Type> {
     fun isPrimitive() = false
 }
 
-data object BotType : Type {
-    override fun joinIdentical(other: Type) = other to TriState.UNKNOWN
+data object BotType : Type, BotTypeLatticeElement<Type> {
     override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
 
     override fun erase(manager: PsiManager, scope: GlobalSearchScope) = this
     override fun match(psiType: PsiType) = TriState.UNKNOWN
 }
 
-data object TopType : Type {
-    override fun joinIdentical(other: Type) = this to TriState.UNKNOWN
+data object TopType : Type, TopTypeLatticeElement<Type> {
+    override fun self() = this
+
     override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
 
     override fun erase(manager: PsiManager, scope: GlobalSearchScope) = this

--- a/src/main/kotlin/de/sirywell/handlehints/type/TypeLatticeElementList.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/TypeLatticeElementList.kt
@@ -42,6 +42,12 @@ sealed interface TypeLatticeElementList<T : TypeLatticeElement<T>> : TypeLattice
 
     fun anyKnownMatches(predicate: (T) -> Boolean): Boolean
 
+    /**
+     * @return a list that contains all known elements, and unknown elements below the maximum known index
+     * represented by [top]
+     */
+    fun partialList(): List<T>
+
     fun topList(): TopTypeLatticeElementList<T>
     fun botList(): BotTypeLatticeElementList<T>
     fun top(): T
@@ -74,6 +80,8 @@ abstract class BotTypeLatticeElementList<T : TypeLatticeElement<T>> : TypeLattic
     override fun sizeOrNull() = null
 
     override fun anyKnownMatches(predicate: (T) -> Boolean) = false
+
+    override fun partialList(): List<T> = listOf()
 }
 
 abstract class TopTypeLatticeElementList<T : TypeLatticeElement<T>> : TypeLatticeElementList<T> {
@@ -93,6 +101,8 @@ abstract class TopTypeLatticeElementList<T : TypeLatticeElement<T>> : TypeLattic
     override fun sizeOrNull() = null
 
     override fun anyKnownMatches(predicate: (T) -> Boolean) = false
+
+    override fun partialList(): List<T> = listOf()
 }
 
 abstract class CompleteTypeLatticeElementList<T : TypeLatticeElement<T>>(val typeList: List<T>) : TypeLatticeElementList<T> {
@@ -179,6 +189,8 @@ abstract class CompleteTypeLatticeElementList<T : TypeLatticeElement<T>>(val typ
     override fun sizeOrNull() = size
 
     override fun anyKnownMatches(predicate: (T) -> Boolean) = typeList.any(predicate)
+
+    override fun partialList() = typeList
 }
 
 abstract class IncompleteTypeLatticeElementList<T : TypeLatticeElement<T>>(val knownTypes: SortedMap<Int, T>) : TypeLatticeElementList<T> {
@@ -257,6 +269,10 @@ abstract class IncompleteTypeLatticeElementList<T : TypeLatticeElement<T>>(val k
     override fun sizeOrNull() = null
 
     override fun anyKnownMatches(predicate: (T) -> Boolean) = knownTypes.values.any(predicate)
+
+    override fun partialList(): List<T> {
+        return (0..knownTypes.lastKey()).map { knownTypes.getOrDefault(it, top()) }
+    }
 }
 
 private fun <T : TypeLatticeElement<T>> TypeLatticeElementList<T>.toMap(): SortedMap<Int, T> {

--- a/src/main/kotlin/de/sirywell/handlehints/type/TypeVisitor.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/TypeVisitor.kt
@@ -29,4 +29,12 @@ interface TypeVisitor<C, R> {
     fun visit(type: ExactLayoutName, context: C): R
     fun visit(type: TopLayoutName, context: C): R
     fun visit(type: BotLayoutName, context: C): R
+    fun visit(type: SequenceElementType, context: C): R
+    fun visit(type: GroupElementType, context: C): R
+    fun visit(type: TopPathElementType, context: C): R
+    fun visit(type: BotPathElementType, context: C): R
+    fun visit(type: TopPathElementList, context: C): R
+    fun visit(type: BotPathElementList, context: C): R
+    fun visit(type: CompletePathElementList, context: C): R
+    fun visit(type: IncompletePathElementList, context: C): R
 }

--- a/src/main/kotlin/de/sirywell/handlehints/type/VarHandleType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/VarHandleType.kt
@@ -2,6 +2,7 @@ package de.sirywell.handlehints.type
 
 import de.sirywell.handlehints.TriState
 
+@TypeInfo(TopVarHandleType::class)
 interface VarHandleType : TypeLatticeElement<VarHandleType> {
     val variableType: Type
     val coordinateTypes: TypeList

--- a/src/main/kotlin/de/sirywell/handlehints/type/meta.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/meta.kt
@@ -1,0 +1,6 @@
+package de.sirywell.handlehints.type
+
+import kotlin.reflect.KClass
+
+@Target(AnnotationTarget.CLASS)
+annotation class TypeInfo(val topType: KClass<out TopTypeLatticeElement<*>>)

--- a/src/main/resources/messages/MethodHandleMessages.properties
+++ b/src/main/resources/messages/MethodHandleMessages.properties
@@ -41,3 +41,7 @@ problem.foreign.memory.alignmentMismatch=Layout must be {0} byte aligned but is 
 problem.foreign.memory.layoutMismatch.adjustPadding=Adjust the padding before this layout
 problem.foreign.memory.layoutMismatch.adjustAlignment=Adjust the alignment of this layout
 problem.foreign.memory.invalidAlignment=This layout cannot be {0} byte aligned due to one of its member layouts.
+problem.foreign.memory.pathTargetNotValueLayout=The layout targeted by the given path is not a 'ValueLayout'.
+problem.foreign.memory.pathElementMismatch=A {0} path element cannot be applied to a {1}.
+problem.foreign.memory.pathGroupElementOutOfBounds=Group element at index {0} exceeds the number of member layouts {1}.
+problem.foreign.memory.pathGroupElementUnknownName=Group layout does not have a member layout with name {0}.

--- a/src/test/kotlin/de/sirywell/handlehints/mhtype/MemoryLayoutTypeTest.kt
+++ b/src/test/kotlin/de/sirywell/handlehints/mhtype/MemoryLayoutTypeTest.kt
@@ -12,6 +12,8 @@ class MemoryLayoutTypeTest : TypeAnalysisTestBase() {
 
     fun testMemoryLayoutSequenceLayout() = doTypeCheckingTest()
 
+    fun testMemoryLayoutVarHandle() = doInspectionAndTypeCheckingTest()
+
     fun testMemoryLayoutWithName() = doTypeCheckingTest()
 
 

--- a/src/test/kotlin/de/sirywell/handlehints/mhtype/TypeAnalysisTestBase.kt
+++ b/src/test/kotlin/de/sirywell/handlehints/mhtype/TypeAnalysisTestBase.kt
@@ -6,6 +6,12 @@ import de.sirywell.handlehints.inspection.MethodHandleEditInspection
 
 abstract class TypeAnalysisTestBase : LightJavaCodeInsightFixtureTestCase() {
 
+    protected fun doInspectionAndTypeCheckingTest() {
+        myFixture.enableInspections(MethodHandleEditInspection())
+        myFixture.enableInspections(MethodHandleTypeHelperInspection { true })
+        myFixture.testHighlighting(true, true, true, getTestName(false) + ".java")
+    }
+
     protected fun doInspectionTest() {
         myFixture.enableInspections(MethodHandleEditInspection())
         myFixture.testHighlighting(true, false, true, getTestName(false) + ".java")

--- a/src/test/testData/MemoryLayoutVarHandle.java
+++ b/src/test/testData/MemoryLayoutVarHandle.java
@@ -1,0 +1,70 @@
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.PaddingLayout;
+import java.lang.foreign.SequenceLayout;
+import java.lang.foreign.StructLayout;
+import java.lang.foreign.UnionLayout;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.VarHandle;
+
+class MemoryLayoutVarHandle {
+    void m(ValueLayout vlU, long any, String unknown) {
+        <info descr="sequenceElement()">MemoryLayout.PathElement pe0 = <info descr="sequenceElement()">MemoryLayout.PathElement.sequenceElement()</info>;</info>
+        <info descr="⊤">VarHandle vh0 = <info descr="⊤">vlU.varHandle()</info>;</info>
+        <info descr="[10:int4]">SequenceLayout sl0 = <info descr="[10:int4]">MemoryLayout.sequenceLayout(10, ValueLayout.JAVA_INT)</info>;</info>
+        <info descr="[?:int4]">SequenceLayout sl1 = <info descr="[?:int4]">MemoryLayout.sequenceLayout(any, ValueLayout.JAVA_INT)</info>;</info>
+        <info descr="[int4]">StructLayout sl2 = <info descr="[int4]">MemoryLayout.structLayout(ValueLayout.JAVA_INT)</info>;</info>
+        <info descr="[int4]">UnionLayout ul0 = <info descr="[int4]">MemoryLayout.unionLayout(ValueLayout.JAVA_INT)</info>;</info>
+        <info descr="[int4(a)]">UnionLayout ul1 = <info descr="[int4(a)]">MemoryLayout.unionLayout(<info descr="int4(a)">ValueLayout.JAVA_INT.withName("a")</info>)</info>;</info>
+        <info descr="[int4(a)|boolean1(b)]">UnionLayout ul2 = <info descr="[int4(a)|boolean1(b)]">MemoryLayout.unionLayout(<info descr="int4(a)">ValueLayout.JAVA_INT.withName("a")</info>, <info descr="boolean1(b)">ValueLayout.JAVA_BOOLEAN.withName("b")</info>)</info>;</info>
+        <info descr="[int4(a)|boolean1(a)]">UnionLayout ul3 = <info descr="[int4(a)|boolean1(a)]">MemoryLayout.unionLayout(<info descr="int4(a)">ValueLayout.JAVA_INT.withName("a")</info>, <info descr="boolean1(a)">ValueLayout.JAVA_BOOLEAN.withName("a")</info>)</info>;</info>
+        <info descr="[int4({⊤})|boolean1(a)]">UnionLayout ul4 = <info descr="[int4({⊤})|boolean1(a)]">MemoryLayout.unionLayout(<info descr="int4({⊤})">ValueLayout.JAVA_INT.withName(unknown)</info>, <info descr="boolean1(a)">ValueLayout.JAVA_BOOLEAN.withName("a")</info>)</info>;</info>
+        <info descr="[int4(a)|boolean1({⊤})]">UnionLayout ul5 = <info descr="[int4(a)|boolean1({⊤})]">MemoryLayout.unionLayout(<info descr="int4(a)">ValueLayout.JAVA_INT.withName("a")</info>, <info descr="boolean1({⊤})">ValueLayout.JAVA_BOOLEAN.withName(unknown)</info>)</info>;</info>
+        // invalid - not a value layout
+        <info descr="⊤">VarHandle vh1 = <info descr="⊤"><warning descr="The layout targeted by the given path is not a 'ValueLayout'.">sl0.varHandle</warning>()</info>;</info>
+        // valid
+        <info descr="(MemorySegment,long)(int)">VarHandle vh2 = <info descr="(MemorySegment,long)(int)">sl0.varHandle(pe0)</info>;</info>
+        <info descr="(MemorySegment)(int)">VarHandle vh3 = <info descr="(MemorySegment)(int)">sl0.varHandle(<info descr="sequenceElement(0)">MemoryLayout.PathElement.sequenceElement(0)</info>)</info>;</info>
+        // invalid index (negative)
+        <info descr="⊤">VarHandle vh4 = <info descr="⊤">sl0.varHandle(<info descr="{⊤}">MemoryLayout.PathElement.sequenceElement(<warning descr="Argument must be >= 0 but is -1.">-1</warning>)</info>)</info>;</info>
+        <info descr="⊤">VarHandle vh5 = <info descr="⊤">sl1.varHandle(<info descr="{⊤}">MemoryLayout.PathElement.sequenceElement(<warning descr="Argument must be >= 0 but is -1.">-1</warning>)</info>)</info>;</info>
+        // we need to assume the index is valid
+        <info descr="(MemorySegment)(int)">VarHandle vh6 = <info descr="(MemorySegment)(int)">sl1.varHandle(<info descr="sequenceElement(12345)">MemoryLayout.PathElement.sequenceElement(12345)</info>)</info>;</info>
+        // a sequence element on a value layout is invalid
+        <info descr="⊤">VarHandle vh7 = <info descr="⊤">sl0.varHandle(<info descr="sequenceElement()">MemoryLayout.PathElement.sequenceElement()</info>, <warning descr="A sequence path element cannot be applied to a ValueLayout."><info descr="sequenceElement()">MemoryLayout.PathElement.sequenceElement()</info></warning>)</info>;</info>
+        <info descr="⊤">VarHandle vh8 = <info descr="⊤">ValueLayout.JAVA_CHAR.varHandle(<warning descr="A sequence path element cannot be applied to a ValueLayout."><info descr="sequenceElement()">MemoryLayout.PathElement.sequenceElement()</info></warning>)</info>;</info>
+        // same for structs, unions, padding
+        <info descr="⊤">VarHandle vh9 = <info descr="⊤">sl2.varHandle(<warning descr="A sequence path element cannot be applied to a StructLayout."><info descr="sequenceElement()">MemoryLayout.PathElement.sequenceElement()</info></warning>)</info>;</info>
+        <info descr="⊤">VarHandle vh10 = <info descr="⊤">ul0.varHandle(<warning descr="A sequence path element cannot be applied to a UnionLayout."><info descr="sequenceElement()">MemoryLayout.PathElement.sequenceElement()</info></warning>)</info>;</info>
+        <info descr="⊤">VarHandle vh11 = <info descr="⊤"><warning descr="The layout targeted by the given path is not a 'ValueLayout'."><info descr="x1">MemoryLayout.paddingLayout(1)</info>.varHandle</warning>()</info>;</info>
+        <info descr="⊤">VarHandle vh12 = <info descr="⊤"><info descr="x1">MemoryLayout.paddingLayout(1)</info>.varHandle(<warning descr="A sequence path element cannot be applied to a PaddingLayout."><info descr="sequenceElement()">MemoryLayout.PathElement.sequenceElement()</info></warning>)</info>;</info>
+        // sequenceElement(start, step)
+        // with invalid step
+        <info descr="⊤">VarHandle vh13 = <info descr="⊤">sl0.varHandle(<info descr="{⊤}">MemoryLayout.PathElement.sequenceElement(0, <warning descr="Argument must be != 0 but is 0.">0</warning>)</info>)</info>;</info>
+        // with invalid start
+        <info descr="⊤">VarHandle vh14 = <info descr="⊤">sl0.varHandle(<info descr="{⊤}">MemoryLayout.PathElement.sequenceElement(<warning descr="Argument must be >= 0 but is -1.">-1</warning>, 1)</info>)</info>;</info>
+        // valid
+        <info descr="(MemorySegment,long)(int)">VarHandle vh15 = <info descr="(MemorySegment,long)(int)">sl0.varHandle(<info descr="sequenceElement(5, -1)">MemoryLayout.PathElement.sequenceElement(5, -1)</info>)</info>;</info>
+        // valid group element via index
+        <info descr="(MemorySegment)(int)">VarHandle vh16 = <info descr="(MemorySegment)(int)">sl2.varHandle(<info descr="groupElement(0)">MemoryLayout.PathElement.groupElement(0)</info>)</info>;</info>
+        // negative group element index
+        <info descr="⊤">VarHandle vh17 = <info descr="⊤">sl2.varHandle(<info descr="{⊤}">MemoryLayout.PathElement.groupElement(<warning descr="Argument must be >= 0 but is -1.">-1</warning>)</info>)</info>;</info>
+        // out of bounds group element index
+        <info descr="⊤">VarHandle vh18 = <info descr="⊤">sl2.varHandle(<warning descr="Group element at index 0 exceeds the number of member layouts 1."><info descr="groupElement(1)">MemoryLayout.PathElement.groupElement(1)</info></warning>)</info>;</info>
+        // unknown index
+        <info descr="⊤">VarHandle vh19 = <info descr="⊤">sl2.varHandle(<info descr="groupElement(index?)">MemoryLayout.PathElement.groupElement(any)</info>)</info>;</info>
+        // valid group element via name
+        <info descr="(MemorySegment)(int)">VarHandle vh20 = <info descr="(MemorySegment)(int)">ul1.varHandle(<info descr="groupElement(a)">MemoryLayout.PathElement.groupElement("a")</info>)</info>;</info>
+        <info descr="(MemorySegment)(int)">VarHandle vh21 = <info descr="(MemorySegment)(int)">ul2.varHandle(<info descr="groupElement(a)">MemoryLayout.PathElement.groupElement("a")</info>)</info>;</info>
+        <info descr="(MemorySegment)(boolean)">VarHandle vh22 = <info descr="(MemorySegment)(boolean)">ul2.varHandle(<info descr="groupElement(b)">MemoryLayout.PathElement.groupElement("b")</info>)</info>;</info>
+        // multiple members named 'a'
+        <info descr="(MemorySegment)(int)">VarHandle vh23 = <info descr="(MemorySegment)(int)">ul3.varHandle(<info descr="groupElement(a)">MemoryLayout.PathElement.groupElement("a")</info>)</info>;</info>
+        // member with unknown name before 'a'
+        <info descr="⊤">VarHandle vh24 = <info descr="⊤">ul4.varHandle(<info descr="groupElement(a)">MemoryLayout.PathElement.groupElement("a")</info>)</info>;</info>
+        // the other way round we find 'a' directly
+        <info descr="(MemorySegment)(int)">VarHandle vh25 = <info descr="(MemorySegment)(int)">ul5.varHandle(<info descr="groupElement(a)">MemoryLayout.PathElement.groupElement("a")</info>)</info>;</info>
+        // no member with that name
+        <info descr="⊤">VarHandle vh26 = <info descr="⊤">ul2.varHandle(<warning descr="Group layout does not have a member layout with name x."><info descr="groupElement(x)">MemoryLayout.PathElement.groupElement("x")</info></warning>)</info>;</info>
+        // with an unknown name, it might exist though
+        <info descr="⊤">VarHandle vh27 = <info descr="⊤">ul5.varHandle(<info descr="groupElement(x)">MemoryLayout.PathElement.groupElement("x")</info>)</info>;</info>
+    }
+}


### PR DESCRIPTION
Supporting layout paths is essential for interaction between the native memory api and VarHandle/MemoryHandle apis.
This is showcased here by the `MemoryLayout#varHandle(...)` method.

`dereferenceElement()` is not supported for now, as this requires an overhaul how address layouts are represented.