### PR TITLE
feature: contribute completions for path layout methods

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/foreign/PathTraverser.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/foreign/PathTraverser.kt
@@ -1,0 +1,166 @@
+package de.sirywell.handlehints.foreign
+
+import com.intellij.util.containers.headTail
+import de.sirywell.handlehints.type.*
+import kotlin.reflect.KClass
+
+interface PathTraverser<T> {
+
+    fun traverse(path: List<PathElementType>, layoutType: MemoryLayoutType, coords: MutableList<Type>): T {
+        return resolvePath(path.withIndex().toList(), layoutType, coords)
+    }
+
+    private tailrec fun resolvePath(
+        path: List<IndexedValue<PathElementType>>,
+        layoutType: MemoryLayoutType,
+        coords: MutableList<Type>
+    ): T {
+        if (layoutType == BotMemoryLayoutType) return onBottomLayout(path, coords)
+        else if (layoutType == TopMemoryLayoutType) return onTopLayout(path, coords)
+        if (path.isEmpty()) {
+            return onPathEmpty(layoutType, coords)
+        }
+        val (head, tail) = path.headTail()
+        onPathElement(head, layoutType)
+        val resolvedLayout = when (head.value) {
+            BotPathElementType -> return onBottomPathElement(path, coords, layoutType)
+            TopPathElementType -> return onTopPathElement(path, coords, layoutType)
+            is SequenceElementType -> sequenceElement(
+                layoutType,
+                // what is wrong with the Kotlin type system?
+                IndexedValue(head.index, head.value as SequenceElementType),
+                coords
+            )
+
+            is GroupElementType -> groupElement(
+                layoutType,
+                IndexedValue(head.index, head.value as GroupElementType)
+            )
+        }
+        return resolvePath(tail, resolvedLayout, coords)
+    }
+
+    private fun sequenceElement(
+        layoutType: MemoryLayoutType,
+        head: IndexedValue<SequenceElementType>,
+        coords: MutableList<Type>
+    ): MemoryLayoutType {
+        val inner = when (layoutType) {
+            BotMemoryLayoutType -> return BotMemoryLayoutType
+            TopMemoryLayoutType -> return TopMemoryLayoutType
+            is SequenceLayoutType -> layoutType.elementLayout
+            is PaddingLayoutType,
+            is StructLayoutType,
+            is UnionLayoutType,
+            is ValueLayoutType -> {
+                return pathElementAndLayoutTypeMismatch(head, layoutType::class, SequenceElementType::class)
+            }
+        }
+        val headVal = head.value
+        when (headVal.variant) {
+            OpenSequenceElementVariant -> coords.add(ExactType.longType)
+            is SelectingOpenSequenceElementVariant -> coords.add(ExactType.longType)
+            is SelectingSequenceElementVariant -> {
+                headVal.variant.index?.let {
+                    val c = layoutType.elementCount ?: Long.MAX_VALUE
+                    if (it >= c) {
+                        return onSequenceElementIndexOutOfBounds(layoutType, it, head)
+                    }
+                }
+            }
+        }
+        return inner
+    }
+
+    private fun groupElement(
+        layoutType: MemoryLayoutType,
+        head: IndexedValue<GroupElementType>
+    ): MemoryLayoutType {
+        return when (layoutType) {
+            BotMemoryLayoutType -> return BotMemoryLayoutType
+            TopMemoryLayoutType -> return TopMemoryLayoutType
+            is StructLayoutType -> findByElementType(head, layoutType.memberLayouts)
+            is UnionLayoutType -> findByElementType(head, layoutType.memberLayouts)
+            is SequenceLayoutType,
+            is PaddingLayoutType,
+            is ValueLayoutType -> {
+                return pathElementAndLayoutTypeMismatch(head, layoutType::class, GroupElementType::class)
+            }
+        }
+    }
+
+    private fun findByElementType(
+        elementType: IndexedValue<GroupElementType>,
+        memberLayouts: MemoryLayoutList
+    ): MemoryLayoutType {
+        return when (elementType.value.variant) {
+            is IndexGroupElementVariant -> {
+                val index = (elementType.value.variant as IndexGroupElementVariant).index
+                if (index == null || index >= Int.MAX_VALUE) TopMemoryLayoutType
+                else if (memberLayouts.compareSize((index + 1).toInt()) == PartialOrder.LT) {
+                    // known index out of bounds
+                    onGroupElementIndexOutOfBounds(elementType, index, memberLayouts)
+                } else memberLayouts[index.toInt()]
+            }
+
+            is NameGroupElementVariant -> {
+                val name = (elementType.value.variant as NameGroupElementVariant).name
+                if (name == null) TopMemoryLayoutType
+                // we need to be conservative here: multiple memberLayouts can have the same name
+                // so we must abort as soon as we find a layout with an unknown name
+                else {
+                    for (type in memberLayouts.partialList()) {
+                        if (type.name !is ExactLayoutName) return TopMemoryLayoutType
+                        else if ((type.name as ExactLayoutName).name == name) return type
+
+                    }
+                    return onGroupElementNameNotFound(elementType, name)
+                }
+            }
+        }
+    }
+
+    fun pathElementAndLayoutTypeMismatch(
+        head: IndexedValue<PathElementType>,
+        memoryLayoutType: KClass<out MemoryLayoutType>,
+        pathElementType: KClass<out PathElementType>
+    ): MemoryLayoutType
+
+    fun onGroupElementNameNotFound(elementType: IndexedValue<GroupElementType>, name: String): MemoryLayoutType
+
+    fun onGroupElementIndexOutOfBounds(
+        elementType: IndexedValue<GroupElementType>,
+        index: Long,
+        memberLayouts: MemoryLayoutList
+    ): MemoryLayoutType
+
+    fun onSequenceElementIndexOutOfBounds(
+        layoutType: SequenceLayoutType,
+        index: Long,
+        head: IndexedValue<SequenceElementType>
+    ): MemoryLayoutType
+
+    fun onComplete(layoutType: ValueLayoutType, coords: MutableList<Type>): T
+
+    fun onPathEmpty(layoutType: MemoryLayoutType, coords: MutableList<Type>): T
+
+    fun onTopPathElement(
+        path: List<IndexedValue<PathElementType>>,
+        coords: MutableList<Type>,
+        layoutType: MemoryLayoutType
+    ): T
+
+    fun onBottomPathElement(
+        path: List<IndexedValue<PathElementType>>,
+        coords: MutableList<Type>,
+        layoutType: MemoryLayoutType
+    ): T
+
+    fun onTopLayout(path: List<IndexedValue<PathElementType>>, coords: MutableList<Type>): T
+
+    fun onBottomLayout(path: List<IndexedValue<PathElementType>>, coords: MutableList<Type>): T
+
+    fun onPathElement(head: IndexedValue<PathElementType>, layoutType: MemoryLayoutType) {
+
+    }
+}

--- a/src/main/kotlin/de/sirywell/handlehints/lookup/HandleHintsReferenceContributor.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/lookup/HandleHintsReferenceContributor.kt
@@ -1,0 +1,195 @@
+package de.sirywell.handlehints.lookup
+
+import com.intellij.codeInsight.completion.*
+import com.intellij.codeInsight.lookup.ExpressionLookupItem
+import com.intellij.codeInsight.lookup.LookupElement
+import com.intellij.patterns.PsiJavaElementPattern
+import com.intellij.patterns.PsiJavaPatterns
+import com.intellij.patterns.PsiMethodPattern
+import com.intellij.psi.JavaPsiFacade
+import com.intellij.psi.PsiElement
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiMethodCallExpression
+import com.intellij.psi.codeStyle.JavaCodeStyleManager
+import com.intellij.psi.util.PsiUtilCore
+import com.intellij.psi.util.parentOfType
+import com.intellij.ui.IconManager
+import com.intellij.ui.PlatformIcons
+import de.sirywell.handlehints.TypeData
+import de.sirywell.handlehints.foreign.PathTraverser
+import de.sirywell.handlehints.type.*
+import javax.swing.Icon
+import kotlin.math.min
+import kotlin.reflect.KClass
+
+class HandleHintsReferenceContributor : CompletionContributor() {
+
+    override fun fillCompletionVariants(parameters: CompletionParameters, result: CompletionResultSet) {
+        fillInPathElements(parameters, result)
+    }
+
+    private fun fillInPathElements(
+        parameters: CompletionParameters,
+        result: CompletionResultSet
+    ) {
+        val pos = parameters.position
+        if (!JavaCompletionContributor.isInJavaContext(pos)) {
+            return
+        }
+        if (!PATH_METHODS_PATTERN.accepts(pos)) {
+            return
+        }
+        val directCall = pos.parentOfType<PsiMethodCallExpression>() ?: return
+        val index = directCall.argumentList.expressions.indexOfFirst { it.text == pos.text }
+        if (index < 0) return
+        val qualifier = directCall.methodExpression.qualifierExpression ?: return
+        val qualifierMemoryLayoutType = TypeData.forFile(pos.containingFile)<MemoryLayoutType>(qualifier) ?: return
+        val targeted = followPath(qualifierMemoryLayoutType, directCall.argumentList.expressions, index) ?: return
+        val factory = JavaPsiFacade.getElementFactory(qualifier.project)
+        val icon = IconManager.getInstance().getPlatformIcon(PlatformIcons.Method)
+        if (targeted is GroupLayoutType) {
+            targeted.memberLayouts.partialList().map { it.name }
+                .filterIsInstance<ExactLayoutName>()
+                .mapNotNull { it.name }
+                .forEach {
+                    val method = "groupElement(\"$it\")"
+                    val short = "PathElement.$method"
+                    val med = "MemoryLayout.$short"
+                    val expressionText = "java.lang.foreign.$med"
+                    val expression = factory.createExpressionFromText(expressionText, qualifier)
+                    val lookupElement = lookupExpression(expression, icon, short, false, short, method, short, med, it)
+                    result.consume(lookupElement)
+                }
+        } else if (targeted is SequenceLayoutType) {
+            val method = "sequenceElement()"
+            val short = "PathElement.$method"
+            val med = "MemoryLayout.$short"
+            val expressionText = "java.lang.foreign.$med"
+            val expression = factory.createExpressionFromText(expressionText, qualifier)
+            val lookupElement = lookupExpression(expression, icon, short, true, short, method, short, med)
+            result.consume(lookupElement)
+        }
+        // TODO AddressLayout/dereferenceElement support
+    }
+
+    private fun toPath(
+        arguments: List<PsiExpression>
+    ): List<PathElementType> {
+        return arguments
+            .map { TypeData.forFile(it.containingFile)<PathElementType>(it) ?: TopPathElementType }
+    }
+
+    // adapted from JavaMethodHandleCompletionContributor
+    private fun lookupExpression(
+        expression: PsiExpression,
+        icon: Icon?,
+        presentableText: String,
+        moveIntoParens: Boolean,
+        vararg lookupText: String
+    ): LookupElement {
+        val element: LookupElement = object : ExpressionLookupItem(expression, icon, presentableText, *lookupText) {
+            override fun handleInsert(context: InsertionContext) {
+                context.document.deleteString(context.startOffset, context.tailOffset)
+                context.commitDocument()
+                replaceText(context, getObject().text)
+                // move caret behind inserted text, user most likely wants to continue there
+                val end = context.tailOffset
+                context.editor.caretModel.currentCaret.moveToOffset(if (moveIntoParens) end - 1 else end)
+            }
+        }
+        return PrioritizedLookupElement.withPriority(element, 1.0)
+    }
+
+    // adapted from JavaMethodHandleCompletionContributor
+    fun replaceText(context: InsertionContext, text: String) {
+        val newElement = PsiUtilCore.getElementAtOffset(context.file, context.startOffset)
+        val params = newElement.parent.parent
+        val end = params.textRange.endOffset - 1
+        val start = min(newElement.textRange.endOffset.toDouble(), end.toDouble()).toInt()
+
+        context.document.replaceString(start, end, text)
+        context.commitDocument()
+        JavaCodeStyleManager.getInstance(context.project)
+            .shortenClassReferences(context.file, context.startOffset, context.tailOffset)
+    }
+
+    private fun followPath(
+        qualifierMemoryLayoutType: MemoryLayoutType,
+        arguments: Array<PsiExpression>,
+        untilIndex: Int
+    ): MemoryLayoutType? {
+        val preceding = arguments.toList().subList(0, untilIndex)
+        val traverser = ReturningPathTraverser()
+        return traverser.traverse(toPath(preceding), qualifierMemoryLayoutType, mutableListOf())
+    }
+}
+
+private val PATH_METHODS_PATTERN: PsiJavaElementPattern.Capture<PsiElement> = PsiJavaPatterns.psiElement()
+    .afterLeaf("(", ",")
+    .withParent(
+        PsiJavaPatterns.psiExpression().methodCallParameter(
+            methodPattern(
+                "arrayElementVarHandle",
+                "byteOffset",
+                "byteOffsetHandle",
+                "select",
+                "sliceHandle",
+                "varHandle"
+            )
+        )
+    )
+
+// adapted from JavaMethodHandleCompletionContributor
+private fun methodPattern(vararg methodNames: String): PsiMethodPattern {
+    return PsiJavaPatterns.psiMethod().withName(*methodNames)
+        .definedInClass("java.lang.foreign.MemoryLayout")
+}
+
+private class ReturningPathTraverser : PathTraverser<MemoryLayoutType?> {
+    override fun pathElementAndLayoutTypeMismatch(
+        head: IndexedValue<PathElementType>,
+        memoryLayoutType: KClass<out MemoryLayoutType>,
+        pathElementType: KClass<out PathElementType>
+    ) = TopMemoryLayoutType
+
+    override fun onGroupElementNameNotFound(
+        elementType: IndexedValue<GroupElementType>,
+        name: String
+    ) = TopMemoryLayoutType
+
+    override fun onGroupElementIndexOutOfBounds(
+        elementType: IndexedValue<GroupElementType>,
+        index: Long,
+        memberLayouts: TypeLatticeElementList<MemoryLayoutType>
+    ) = TopMemoryLayoutType
+
+    override fun onSequenceElementIndexOutOfBounds(
+        layoutType: SequenceLayoutType,
+        index: Long,
+        head: IndexedValue<SequenceElementType>
+    ) = TopMemoryLayoutType
+
+    override fun onComplete(layoutType: ValueLayoutType, coords: MutableList<Type>) = null
+
+    override fun onPathEmpty(layoutType: MemoryLayoutType, coords: MutableList<Type>) = layoutType
+
+    override fun onTopPathElement(
+        path: List<IndexedValue<PathElementType>>,
+        coords: MutableList<Type>,
+        layoutType: MemoryLayoutType
+    ) = null
+
+    override fun onBottomPathElement(
+        path: List<IndexedValue<PathElementType>>,
+        coords: MutableList<Type>,
+        layoutType: MemoryLayoutType
+    ) = null
+
+    override fun onTopLayout(path: List<IndexedValue<PathElementType>>, coords: MutableList<Type>) = null
+
+    override fun onBottomLayout(
+        path: List<IndexedValue<PathElementType>>,
+        coords: MutableList<Type>
+    ) = null
+
+}

--- a/src/main/kotlin/de/sirywell/handlehints/presentation/TypeInlayHintsCollector.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/presentation/TypeInlayHintsCollector.kt
@@ -37,6 +37,9 @@ class TypeInlayHintsCollector : SharedBypassCollector {
         if (type is TopTypeLatticeElement || type is BotTypeLatticeElement) {
             return
         }
+        if (type is PathElementType) {
+            return // don't print path elements for now
+        }
         sink.addPresentation(InlineInlayPosition(pos, belongsToBefore), hasBackground = true) {
             text(TypePrinter().print(type))
         }

--- a/src/main/kotlin/de/sirywell/handlehints/type/MemoryLayoutType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/MemoryLayoutType.kt
@@ -75,12 +75,16 @@ data class ValueLayoutType(
     override fun withName(name: LayoutName) = ValueLayoutType(type, byteAlignment, byteSize, name)
 }
 
+sealed interface GroupLayoutType : MemoryLayoutType {
+    val memberLayouts: MemoryLayoutList
+}
+
 data class StructLayoutType(
-    val memberLayouts: MemoryLayoutList,
+    override val memberLayouts: MemoryLayoutList,
     override val byteAlignment: Long?,
     override val byteSize: Long?,
     override val name: LayoutName
-) : MemoryLayoutType {
+) : GroupLayoutType {
     override fun withByteAlignment(byteAlignment: Long) =
         StructLayoutType(this.memberLayouts, byteSize, byteAlignment, name)
 
@@ -107,11 +111,11 @@ data class StructLayoutType(
 }
 
 data class UnionLayoutType(
-    val memberLayouts: MemoryLayoutList,
+    override val memberLayouts: MemoryLayoutList,
     override val byteAlignment: Long?,
     override val byteSize: Long?,
     override val name: LayoutName
-) : MemoryLayoutType {
+) : GroupLayoutType {
     override fun withByteAlignment(byteAlignment: Long): MemoryLayoutType {
         return UnionLayoutType(this.memberLayouts, byteSize, byteAlignment, name)
     }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,6 +27,8 @@
         <platform.backend.documentation.psiTargetProvider
                 id="TypeDocumentationTargetProvider"
                 implementation="de.sirywell.handlehints.presentation.TypeDocumentationTargetProvider"/>
+        <completion.contributor language="JAVA"
+                                implementationClass="de.sirywell.handlehints.lookup.HandleHintsReferenceContributor"/>
     </extensions>
 
     <applicationListeners>


### PR DESCRIPTION
Layout paths can be annoying to type. If we know the layout, we can help by providing completions for group layout names and sequence elements.

In future, we can expand this to dereference elements.