### PR TITLE
feature: specialize AddressLayout to support target layouts

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/dfa/SsaAnalyzer.kt
@@ -343,29 +343,39 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, val typeData: TypeData) 
                 memoryLayoutHelper.varHandle(qualifier, arguments, methodExpression, block)
             }
 
+            // AddressLayout specifics
+            "withoutTargetLayout" -> {
+                if (qualifier == null) return noMatch()
+                memoryLayoutHelper.withoutTargetLayout(qualifier, block)
+            }
+            "withTargetLayout" -> {
+                if (qualifier == null || arguments.size != 1) return noMatch()
+                memoryLayoutHelper.withTargetLayout(qualifier, arguments[0], block)
+            }
+
             else -> noMatch()
         }
     }
 
-    private fun extractValueLayoutType(variable: PsiVariable): ValueLayoutType? {
+    private fun extractValueLayoutType(variable: PsiVariable): MemoryLayoutType? {
         val name = variable.name ?: return null
         return when (name) {
-            "ADDRESS" -> ValueLayoutType(ADDRESS_TYPE, null, null)
-            "ADDRESS_UNALIGNED" -> ValueLayoutType(ADDRESS_TYPE, 1, 1)
-            "JAVA_BOOLEAN" -> ValueLayoutType(ExactType.booleanType, 1, 1)
-            "JAVA_BYTE" -> ValueLayoutType(ExactType.byteType, 1, 1)
-            "JAVA_CHAR" -> ValueLayoutType(ExactType.charType, 2, 2)
-            "JAVA_CHAR_UNALIGNED" -> ValueLayoutType(ExactType.charType, 1, 2)
-            "JAVA_DOUBLE" -> ValueLayoutType(ExactType.doubleType, 8, 8)
-            "JAVA_DOUBLE_UNALIGNED" -> ValueLayoutType(ExactType.doubleType, 1, 8)
-            "JAVA_FLOAT" -> ValueLayoutType(ExactType.floatType, 4, 4)
-            "JAVA_FLOAT_UNALIGNED" -> ValueLayoutType(ExactType.floatType, 1, 4)
-            "JAVA_INT" -> ValueLayoutType(ExactType.intType, 4, 4)
-            "JAVA_INT_UNALIGNED" -> ValueLayoutType(ExactType.intType, 1, 4)
-            "JAVA_LONG" -> ValueLayoutType(ExactType.longType, 8, 8)
-            "JAVA_LONG_UNALIGNED" -> ValueLayoutType(ExactType.longType, 1, 8)
-            "JAVA_SHORT" -> ValueLayoutType(ExactType.shortType, 2, 2)
-            "JAVA_SHORT_UNALIGNED" -> ValueLayoutType(ExactType.shortType, 1, 2)
+            "ADDRESS" -> AddressLayoutType(null, null)
+            "ADDRESS_UNALIGNED" -> AddressLayoutType(1, 1)
+            "JAVA_BOOLEAN" -> NormalValueLayoutType(ExactType.booleanType, 1, 1)
+            "JAVA_BYTE" -> NormalValueLayoutType(ExactType.byteType, 1, 1)
+            "JAVA_CHAR" -> NormalValueLayoutType(ExactType.charType, 2, 2)
+            "JAVA_CHAR_UNALIGNED" -> NormalValueLayoutType(ExactType.charType, 1, 2)
+            "JAVA_DOUBLE" -> NormalValueLayoutType(ExactType.doubleType, 8, 8)
+            "JAVA_DOUBLE_UNALIGNED" -> NormalValueLayoutType(ExactType.doubleType, 1, 8)
+            "JAVA_FLOAT" -> NormalValueLayoutType(ExactType.floatType, 4, 4)
+            "JAVA_FLOAT_UNALIGNED" -> NormalValueLayoutType(ExactType.floatType, 1, 4)
+            "JAVA_INT" -> NormalValueLayoutType(ExactType.intType, 4, 4)
+            "JAVA_INT_UNALIGNED" -> NormalValueLayoutType(ExactType.intType, 1, 4)
+            "JAVA_LONG" -> NormalValueLayoutType(ExactType.longType, 8, 8)
+            "JAVA_LONG_UNALIGNED" -> NormalValueLayoutType(ExactType.longType, 1, 8)
+            "JAVA_SHORT" -> NormalValueLayoutType(ExactType.shortType, 2, 2)
+            "JAVA_SHORT_UNALIGNED" -> NormalValueLayoutType(ExactType.shortType, 1, 2)
             else -> null
         }
     }

--- a/src/main/kotlin/de/sirywell/handlehints/presentation/TypePrinter.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/presentation/TypePrinter.kt
@@ -104,7 +104,15 @@ class TypePrinter : TypeVisitor<TypePrinter.PrintContext, Unit> {
         context.append("⊤")
     }
 
-    override fun visit(type: ValueLayoutType, context: PrintContext) {
+    override fun visit(type: AddressLayoutType, context: PrintContext) {
+        context.append("a?")
+        if (type.targetLayout != null) {
+            context.append(":")
+            type.targetLayout.accept(this, context)
+        }
+    }
+
+    override fun visit(type: NormalValueLayoutType, context: PrintContext) {
         if (type.byteSize == null || type.byteSize != type.byteAlignment) {
             context.append(type.byteAlignment ?: "?").append("%")
         }

--- a/src/main/kotlin/de/sirywell/handlehints/type/TypeVisitor.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/TypeVisitor.kt
@@ -17,7 +17,8 @@ interface TypeVisitor<C, R> {
     fun visit(type: CompleteMethodHandleType, context: C): R
     fun visit(type: BotMemoryLayoutType, context: C): R
     fun visit(type: TopMemoryLayoutType, context: C): R
-    fun visit(type: ValueLayoutType, context: C): R
+    fun visit(type: AddressLayoutType, context: C): R
+    fun visit(type: NormalValueLayoutType, context: C): R
     fun visit(type: StructLayoutType, context: C): R
     fun visit(type: UnionLayoutType, context: C): R
     fun visit(type: SequenceLayoutType, context: C): R


### PR DESCRIPTION
Introducing a new type for `AddressLayout`s. The main reason for that is to support `PathElement#dereferenceElement()`.