### PR TITLE
feature: PathElement#dereferenceElement support

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/dfa/SsaAnalyzer.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/dfa/SsaAnalyzer.kt
@@ -318,7 +318,10 @@ class SsaAnalyzer(private val controlFlow: ControlFlow, val typeData: TypeData) 
                 if (arguments.size != 1) noMatch()
                 else pathElementHelper.groupElement(arguments[0])
             }
-
+            "dereferenceElement" -> {
+                if (arguments.isNotEmpty()) return noMatch()
+                else pathElementHelper.dereferenceElement()
+            }
             else -> noMatch()
         }
     }

--- a/src/main/kotlin/de/sirywell/handlehints/foreign/MemoryLayoutHelper.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/foreign/MemoryLayoutHelper.kt
@@ -232,6 +232,10 @@ class MemoryLayoutHelper(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(
             coords: MutableList<Type>
         ) = BotVarHandleType // TODO does that make sense?
 
+        override fun invalidAddressDereference(head: IndexedValue<DereferenceElementType>): MemoryLayoutType {
+            return emitProblem(contextElement(head.index), message("problem.foreign.memory.dereferenceElementInvalid"))
+        }
+
         override fun pathElementAndLayoutTypeMismatch(
             head: IndexedValue<PathElementType>,
             memoryLayoutType: KClass<out MemoryLayoutType>,

--- a/src/main/kotlin/de/sirywell/handlehints/foreign/PathElementHelper.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/foreign/PathElementHelper.kt
@@ -60,4 +60,8 @@ class PathElementHelper(ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(ssaAnalyzer.t
         }
         return TopPathElementType
     }
+
+    fun dereferenceElement(): PathElementType {
+        return DereferenceElementType
+    }
 }

--- a/src/main/kotlin/de/sirywell/handlehints/foreign/PathTraverser.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/foreign/PathTraverser.kt
@@ -36,9 +36,34 @@ interface PathTraverser<T> {
                 layoutType,
                 IndexedValue(head.index, head.value as GroupElementType)
             )
+
+            DereferenceElementType -> dereferenceElement(layoutType, IndexedValue(head.index, DereferenceElementType))
         }
         return resolvePath(tail, resolvedLayout, coords)
     }
+
+    fun dereferenceElement(
+        layoutType: MemoryLayoutType,
+        head: IndexedValue<DereferenceElementType>
+    ): MemoryLayoutType {
+        return when (layoutType) {
+            BotMemoryLayoutType -> return BotMemoryLayoutType
+            TopMemoryLayoutType -> return TopMemoryLayoutType
+            is AddressLayoutType -> {
+                layoutType.targetLayout ?: // knowingly no target layout present
+                return invalidAddressDereference(head)
+            }
+            is StructLayoutType,
+            is UnionLayoutType,
+            is PaddingLayoutType,
+            is SequenceLayoutType,
+            is NormalValueLayoutType -> {
+                return pathElementAndLayoutTypeMismatch(head, layoutType::class, DereferenceElementType::class)
+            }
+        }
+    }
+
+    fun invalidAddressDereference(head: IndexedValue<DereferenceElementType>): MemoryLayoutType
 
     private fun sequenceElement(
         layoutType: MemoryLayoutType,

--- a/src/main/kotlin/de/sirywell/handlehints/lookup/HandleHintsReferenceContributor.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/lookup/HandleHintsReferenceContributor.kt
@@ -68,8 +68,15 @@ class HandleHintsReferenceContributor : CompletionContributor() {
             val expression = factory.createExpressionFromText(expressionText, qualifier)
             val lookupElement = lookupExpression(expression, icon, short, true, short, method, short, med)
             result.consume(lookupElement)
+        } else if (targeted is AddressLayoutType && targeted.targetLayout != null) {
+            val method = "dereferenceElement()"
+            val short = "PathElement.$method"
+            val med = "MemoryLayout.$short"
+            val expressionText = "java.lang.foreign.$med"
+            val expression = factory.createExpressionFromText(expressionText, qualifier)
+            val lookupElement = lookupExpression(expression, icon, short, false, short, method, short, med)
+            result.consume(lookupElement)
         }
-        // TODO AddressLayout/dereferenceElement support
     }
 
     private fun toPath(
@@ -146,6 +153,8 @@ private fun methodPattern(vararg methodNames: String): PsiMethodPattern {
 }
 
 private class ReturningPathTraverser : PathTraverser<MemoryLayoutType?> {
+    override fun invalidAddressDereference(head: IndexedValue<DereferenceElementType>) = TopMemoryLayoutType
+
     override fun pathElementAndLayoutTypeMismatch(
         head: IndexedValue<PathElementType>,
         memoryLayoutType: KClass<out MemoryLayoutType>,

--- a/src/main/kotlin/de/sirywell/handlehints/presentation/TypePrinter.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/presentation/TypePrinter.kt
@@ -211,6 +211,23 @@ class TypePrinter : TypeVisitor<TypePrinter.PrintContext, Unit> {
         }
     }
 
+    override fun visit(type: GroupElementType, context: PrintContext) {
+        when (type.variant) {
+            is IndexGroupElementVariant -> context.append("groupElement(")
+                .append((type.variant.index ?: "index?").toString())
+                .append(")")
+
+            is NameGroupElementVariant -> context.append("groupElement(")
+                .append((type.variant.name ?: "name?").toString())
+                .append(")")
+
+        }
+    }
+
+    override fun visit(type: DereferenceElementType, context: PrintContext) {
+        context.append("dereferenceElement()")
+    }
+
     override fun visit(type: TopPathElementType, context: PrintContext) {
         context.append("{⊤}")
     }
@@ -237,19 +254,6 @@ class TypePrinter : TypeVisitor<TypePrinter.PrintContext, Unit> {
             context.append("->")
         }
         context.append("...")
-    }
-
-    override fun visit(type: GroupElementType, context: PrintContext) {
-        when (type.variant) {
-            is IndexGroupElementVariant -> context.append("groupElement(")
-                .append((type.variant.index ?: "index?").toString())
-                .append(")")
-
-            is NameGroupElementVariant -> context.append("groupElement(")
-                .append((type.variant.name ?: "name?").toString())
-                .append(")")
-
-        }
     }
 
 }

--- a/src/main/kotlin/de/sirywell/handlehints/type/TypeVisitor.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/TypeVisitor.kt
@@ -32,6 +32,7 @@ interface TypeVisitor<C, R> {
     fun visit(type: BotLayoutName, context: C): R
     fun visit(type: SequenceElementType, context: C): R
     fun visit(type: GroupElementType, context: C): R
+    fun visit(type: DereferenceElementType, context: C): R
     fun visit(type: TopPathElementType, context: C): R
     fun visit(type: BotPathElementType, context: C): R
     fun visit(type: TopPathElementList, context: C): R

--- a/src/main/resources/messages/MethodHandleMessages.properties
+++ b/src/main/resources/messages/MethodHandleMessages.properties
@@ -45,3 +45,4 @@ problem.foreign.memory.pathTargetNotValueLayout=The layout targeted by the given
 problem.foreign.memory.pathElementMismatch=A {0} path element cannot be applied to a {1}.
 problem.foreign.memory.pathGroupElementOutOfBounds=Group element at index {0} exceeds the number of member layouts {1}.
 problem.foreign.memory.pathGroupElementUnknownName=Group layout does not have a member layout with name {0}.
+problem.foreign.memory.dereferenceElementInvalid=Address layout has no target layout to dereference.

--- a/src/test/testData/MemoryLayoutVarHandle.java
+++ b/src/test/testData/MemoryLayoutVarHandle.java
@@ -1,3 +1,4 @@
+import java.lang.foreign.AddressLayout;
 import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.PaddingLayout;
 import java.lang.foreign.SequenceLayout;
@@ -19,6 +20,11 @@ class MemoryLayoutVarHandle {
         <info descr="[int4(a)|boolean1(a)]">UnionLayout ul3 = <info descr="[int4(a)|boolean1(a)]">MemoryLayout.unionLayout(<info descr="int4(a)">ValueLayout.JAVA_INT.withName("a")</info>, <info descr="boolean1(a)">ValueLayout.JAVA_BOOLEAN.withName("a")</info>)</info>;</info>
         <info descr="[int4({⊤})|boolean1(a)]">UnionLayout ul4 = <info descr="[int4({⊤})|boolean1(a)]">MemoryLayout.unionLayout(<info descr="int4({⊤})">ValueLayout.JAVA_INT.withName(unknown)</info>, <info descr="boolean1(a)">ValueLayout.JAVA_BOOLEAN.withName("a")</info>)</info>;</info>
         <info descr="[int4(a)|boolean1({⊤})]">UnionLayout ul5 = <info descr="[int4(a)|boolean1({⊤})]">MemoryLayout.unionLayout(<info descr="int4(a)">ValueLayout.JAVA_INT.withName("a")</info>, <info descr="boolean1({⊤})">ValueLayout.JAVA_BOOLEAN.withName(unknown)</info>)</info>;</info>
+        <info descr="4%[[int4(s00)](s0)[int4(s10)](s1)]">StructLayout sl3 = <info descr="4%[[int4(s00)](s0)[int4(s10)](s1)]">MemoryLayout.structLayout(
+                <info descr="[int4(s00)](s0)"><info descr="[int4(s00)]">MemoryLayout.structLayout(<info descr="int4(s00)">ValueLayout.JAVA_INT.withName("s00")</info>)</info>.withName("s0")</info>,
+                <info descr="[int4(s10)](s1)"><info descr="[int4(s10)]">MemoryLayout.structLayout(<info descr="int4(s10)">ValueLayout.JAVA_INT.withName("s10")</info>)</info>.withName("s1")</info>
+        )</info>;</info>
+        <info descr="a?:[int4(a)|boolean1(b)]">AddressLayout al0 = <info descr="a?:[int4(a)|boolean1(b)]">ValueLayout.ADDRESS.withTargetLayout(ul2)</info>;</info>
         // invalid - not a value layout
         <info descr="⊤">VarHandle vh1 = <info descr="⊤"><warning descr="The layout targeted by the given path is not a 'ValueLayout'.">sl0.varHandle</warning>()</info>;</info>
         // valid
@@ -66,5 +72,9 @@ class MemoryLayoutVarHandle {
         <info descr="(0=MemorySegment)(⊤)">VarHandle vh26 = <info descr="(0=MemorySegment)(⊤)">ul2.varHandle(<warning descr="Group layout does not have a member layout with name x."><info descr="groupElement(x)">MemoryLayout.PathElement.groupElement("x")</info></warning>)</info>;</info>
         // with an unknown name, it might exist though
         <info descr="(0=MemorySegment)(⊤)">VarHandle vh27 = <info descr="(0=MemorySegment)(⊤)">ul5.varHandle(<info descr="groupElement(x)">MemoryLayout.PathElement.groupElement("x")</info>)</info>;</info>
+        // nested
+        <info descr="(MemorySegment)(int)">VarHandle vh28 = <info descr="(MemorySegment)(int)">sl3.varHandle(<info descr="groupElement(1)">MemoryLayout.PathElement.groupElement(1)</info>, <info descr="groupElement(0)">MemoryLayout.PathElement.groupElement(0)</info>)</info>;</info>
+        // dereference
+        <info descr="(MemorySegment)(int)">VarHandle vh29 = <info descr="(MemorySegment)(int)">al0.varHandle(<info descr="dereferenceElement()">MemoryLayout.PathElement.dereferenceElement()</info>, <info descr="groupElement(a)">MemoryLayout.PathElement.groupElement("a")</info>)</info>;</info>
     }
 }


### PR DESCRIPTION
With the new `AddressLayout` modelling, we can support `dereferenceElement()`, including completions and inspections.