### PR TITLE
fix: avoid usage of internal api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Avoid usage of internal API for method icons
+
 ## [0.2.0] - 2024-08-11
 
 ### Added

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = de.sirywell.handlehints
 pluginName = HandleHints
 pluginRepositoryUrl = https://github.com/SirYwell/HandleHints
 # SemVer format -> https://semver.org
-pluginVersion = 0.2.0
+pluginVersion = 0.2.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233

--- a/src/main/kotlin/de/sirywell/handlehints/lookup/HandleHintsReferenceContributor.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/lookup/HandleHintsReferenceContributor.kt
@@ -13,8 +13,7 @@ import com.intellij.psi.PsiMethodCallExpression
 import com.intellij.psi.codeStyle.JavaCodeStyleManager
 import com.intellij.psi.util.PsiUtilCore
 import com.intellij.psi.util.parentOfType
-import com.intellij.ui.IconManager
-import com.intellij.ui.PlatformIcons
+import com.intellij.util.PlatformIcons
 import de.sirywell.handlehints.TypeData
 import de.sirywell.handlehints.foreign.PathTraverser
 import de.sirywell.handlehints.type.*
@@ -46,7 +45,7 @@ class HandleHintsReferenceContributor : CompletionContributor() {
         val qualifierMemoryLayoutType = TypeData.forFile(pos.containingFile)<MemoryLayoutType>(qualifier) ?: return
         val targeted = followPath(qualifierMemoryLayoutType, directCall.argumentList.expressions, index) ?: return
         val factory = JavaPsiFacade.getElementFactory(qualifier.project)
-        val icon = IconManager.getInstance().getPlatformIcon(PlatformIcons.Method)
+        val icon = PlatformIcons.METHOD_ICON
         if (targeted is GroupLayoutType) {
             targeted.memberLayouts.partialList().map { it.name }
                 .filterIsInstance<ExactLayoutName>()


### PR DESCRIPTION
The method icon needs to be referenced differently.