### PR TITLE
feature: FunctionDescriptor type analysis

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/foreign/FunctionDescriptorHelper.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/foreign/FunctionDescriptorHelper.kt
@@ -1,0 +1,81 @@
+package de.sirywell.handlehints.foreign
+
+import com.intellij.psi.PsiExpression
+import com.intellij.psi.PsiType
+import de.sirywell.handlehints.dfa.SsaAnalyzer
+import de.sirywell.handlehints.dfa.SsaConstruction
+import de.sirywell.handlehints.getConstantOfType
+import de.sirywell.handlehints.inspection.ProblemEmitter
+import de.sirywell.handlehints.type.*
+
+class FunctionDescriptorHelper(private val ssaAnalyzer: SsaAnalyzer) : ProblemEmitter(ssaAnalyzer.typeData) {
+
+    fun of(
+        resLayoutExpr: PsiExpression,
+        argLayoutExprs: List<PsiExpression>,
+        block: SsaConstruction.Block
+    ): FunctionDescriptorType {
+        val resLayout = ssaAnalyzer.memoryLayoutType(resLayoutExpr, block) ?: TopMemoryLayoutType
+        val argLayouts = argLayoutExprs.map { ssaAnalyzer.memoryLayoutType(it, block) ?: TopMemoryLayoutType }
+        return CompleteFunctionDescriptorType(CompleteMemoryLayoutList(argLayouts), resLayout)
+    }
+
+    fun ofVoid(argLayoutExprs: List<PsiExpression>, block: SsaConstruction.Block): FunctionDescriptorType {
+        val resLayout = VOID_RETURN_TYPE
+        val argLayouts = argLayoutExprs.map { ssaAnalyzer.memoryLayoutType(it, block) ?: TopMemoryLayoutType }
+        return CompleteFunctionDescriptorType(CompleteMemoryLayoutList(argLayouts), resLayout)
+    }
+
+    fun dropReturnLayout(qualifier: PsiExpression, block: SsaConstruction.Block): FunctionDescriptorType {
+        val q = ssaAnalyzer.functionDescriptorType(qualifier, block) ?: TopFunctionDescriptorType
+        return q.withReturnType(VOID_RETURN_TYPE)
+    }
+
+    fun appendArgumentLayouts(
+        qualifier: PsiExpression,
+        argumentExprs: List<PsiExpression>,
+        block: SsaConstruction.Block
+    ): FunctionDescriptorType {
+        val q = ssaAnalyzer.functionDescriptorType(qualifier, block) ?: TopFunctionDescriptorType
+        val argLayouts = argumentExprs.map { ssaAnalyzer.memoryLayoutType(it, block) ?: TopMemoryLayoutType }
+        val currentParams = q.parameterTypes as? CompleteMemoryLayoutList ?: return TopFunctionDescriptorType
+        val newParams = currentParams.addAllAt(currentParams.size, CompleteMemoryLayoutList(argLayouts))
+        return CompleteFunctionDescriptorType(newParams, q.returnType)
+    }
+
+    fun changeReturnLayout(
+        qualifier: PsiExpression,
+        newReturnExpr: PsiExpression,
+        block: SsaConstruction.Block
+    ): FunctionDescriptorType {
+        val q = ssaAnalyzer.functionDescriptorType(qualifier, block) ?: TopFunctionDescriptorType
+        val resLayout = ssaAnalyzer.memoryLayoutType(newReturnExpr, block) ?: TopMemoryLayoutType
+        return q.withReturnType(resLayout)
+    }
+
+    fun insertArgumentLayouts(
+        qualifier: PsiExpression,
+        indexExpr: PsiExpression,
+        addedLayoutExprs: List<PsiExpression>,
+        block: SsaConstruction.Block
+    ): FunctionDescriptorType {
+        val q = ssaAnalyzer.functionDescriptorType(qualifier, block) ?: TopFunctionDescriptorType
+        val index = indexExpr.getConstantOfType<Int>() ?: return TopFunctionDescriptorType
+        val argLayouts = addedLayoutExprs.map { ssaAnalyzer.memoryLayoutType(it, block) ?: TopMemoryLayoutType }
+        val currentParams = q.parameterTypes
+        val newParams = currentParams.addAllAt(index, CompleteMemoryLayoutList(argLayouts))
+        return CompleteFunctionDescriptorType(newParams, q.returnType)
+    }
+
+    fun toMethodType(qualifier: PsiExpression, block: SsaConstruction.Block): MethodHandleType {
+        val q = ssaAnalyzer.functionDescriptorType(qualifier, block) ?: TopFunctionDescriptorType
+        val memorySegmentType = ExactType(
+            PsiType.getTypeByName(
+                "java.lang.foreign.MemorySegment",
+                qualifier.project,
+                qualifier.resolveScope
+            )
+        )
+        return q.toMethodType(memorySegmentType)
+    }
+}

--- a/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
@@ -40,6 +40,10 @@ fun receiverIsPathElement(element: PsiMethodCallExpression): Boolean {
     return element.resolveMethod()?.containingClass?.qualifiedName == "java.lang.foreign.MemoryLayout.PathElement"
 }
 
+fun receiverIsFunctionDescriptor(element: PsiMethodCallExpression): Boolean {
+    return element.resolveMethod()?.containingClass?.qualifiedName == "java.lang.foreign.FunctionDescriptor"
+}
+
 fun methodHandleType(element: PsiElement): PsiClassType {
     return PsiType.getTypeByName("java.lang.invoke.MethodHandle", element.project, element.resolveScope)
 }
@@ -54,6 +58,10 @@ fun methodTypeType(element: PsiElement): PsiClassType {
 
 fun pathElementType(element: PsiElement): PsiClassType {
     return PsiType.getTypeByName("java.lang.foreign.MemoryLayout.PathElement", element.project, element.resolveScope)
+}
+
+fun functionDescriptorType(element: PsiElement): PsiClassType {
+    return PsiType.getTypeByName("java.lang.foreign.FunctionDescriptor", element.project, element.resolveScope)
 }
 
 fun objectType(element: PsiElement): PsiType {
@@ -174,5 +182,6 @@ fun isUnrelated(type: PsiType, context: PsiElement): Boolean {
             && type != methodHandleType(context)
             && type != varHandleType(context)
             && type != pathElementType(context)
+            && type != functionDescriptorType(context)
             && type !in memoryLayoutTypes(context)
 }

--- a/src/main/kotlin/de/sirywell/handlehints/type/FunctionDescriptorType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/FunctionDescriptorType.kt
@@ -1,0 +1,110 @@
+package de.sirywell.handlehints.type
+
+import de.sirywell.handlehints.TriState
+
+@TypeInfo(TopFunctionDescriptorType::class)
+sealed interface FunctionDescriptorType : FunctionType<FunctionDescriptorType, MemoryLayoutType> {
+    override fun withParameterTypes(parameterTypes: List<MemoryLayoutType>): FunctionDescriptorType {
+        return withParameterTypes(CompleteMemoryLayoutList(parameterTypes))
+    }
+
+    fun toMethodType(memorySegmentType: Type): MethodHandleType
+}
+
+data object BotFunctionDescriptorType : FunctionDescriptorType, BotTypeLatticeElement<FunctionDescriptorType> {
+    override fun joinIdentical(other: FunctionDescriptorType) = other to TriState.UNKNOWN
+
+    override fun withReturnType(returnType: MemoryLayoutType) =
+        CompleteFunctionDescriptorType(parameterTypes, returnType)
+
+    override fun withParameterTypes(parameterTypes: MemoryLayoutList) =
+        CompleteFunctionDescriptorType(parameterTypes, returnType)
+
+    override fun toMethodType(memorySegmentType: Type) = BotMethodHandleType
+
+    override fun parameterTypeAt(index: Int) = BotMemoryLayoutType
+
+    override val returnType get() = BotMemoryLayoutType
+
+    override val parameterTypes get() = BotMemoryLayoutList
+
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
+}
+
+
+data object TopFunctionDescriptorType : FunctionDescriptorType, TopTypeLatticeElement<FunctionDescriptorType> {
+    override fun joinIdentical(other: FunctionDescriptorType) = this to TriState.UNKNOWN
+
+    override fun withReturnType(returnType: MemoryLayoutType) = this
+
+    override fun withParameterTypes(parameterTypes: MemoryLayoutList) = this
+
+    override fun toMethodType(memorySegmentType: Type) = TopMethodHandleType
+
+    override fun parameterTypeAt(index: Int) = TopMemoryLayoutType
+
+    override val returnType get() = TopMemoryLayoutType
+
+    override val parameterTypes get() = TopMemoryLayoutList
+
+    override fun self() = this
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C) = visitor.visit(this, context)
+}
+
+data class CompleteFunctionDescriptorType(
+    override val parameterTypes: TypeLatticeElementList<MemoryLayoutType>,
+    override val returnType: MemoryLayoutType
+) : FunctionDescriptorType, CompleteFunctionType<FunctionDescriptorType, MemoryLayoutType> {
+    override fun withParameterTypes(parameterTypes: List<MemoryLayoutType>): FunctionDescriptorType {
+        return withParameterTypes(CompleteMemoryLayoutList(parameterTypes))
+    }
+
+    override fun toMethodType(memorySegmentType: Type): MethodHandleType {
+        return CompleteMethodHandleType(
+            memoryLayoutToType(returnType, memorySegmentType),
+            mapMemoryLayoutListToTypeList(parameterTypes, memorySegmentType),
+            TriState.NO
+        )
+    }
+
+    override fun <C, R> accept(visitor: TypeVisitor<C, R>, context: C): R {
+        return visitor.visit(this, context)
+    }
+
+    override fun copy(
+        returnType: MemoryLayoutType,
+        parameterTypes: TypeLatticeElementList<MemoryLayoutType>
+    ): FunctionDescriptorType {
+        return CompleteFunctionDescriptorType(parameterTypes, returnType)
+    }
+}
+
+private fun mapMemoryLayoutListToTypeList(parameterTypes: MemoryLayoutList, memorySegmentType: Type): TypeList {
+    return when (parameterTypes) {
+        is BotTypeLatticeElementList -> BotTypeList
+        is TopTypeLatticeElementList -> TopTypeList
+        is CompleteTypeLatticeElementList -> {
+            val params = parameterTypes.typeList.map { memoryLayoutToType(it, memorySegmentType) }
+            CompleteTypeList(params)
+        }
+
+        is IncompleteTypeLatticeElementList -> {
+            val params = parameterTypes.knownTypes.mapValues { (_, v) -> memoryLayoutToType(v, memorySegmentType) }
+            IncompleteTypeList(params.toSortedMap())
+        }
+    }
+}
+
+private fun memoryLayoutToType(layoutType: MemoryLayoutType, memorySegmentType: Type): Type {
+    return when (layoutType) {
+        BotMemoryLayoutType -> BotType
+        TopMemoryLayoutType -> TopType
+        is StructLayoutType,
+        is UnionLayoutType,
+        is PaddingLayoutType,
+        is SequenceLayoutType,
+        is AddressLayoutType -> memorySegmentType
+
+        is NormalValueLayoutType -> layoutType.type
+    }
+}

--- a/src/main/kotlin/de/sirywell/handlehints/type/FunctionType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/FunctionType.kt
@@ -1,0 +1,41 @@
+package de.sirywell.handlehints.type
+
+import de.sirywell.handlehints.TriState
+
+/**
+ * A generic type representing functions consisting of parameters and a return type of type [T].
+ */
+sealed interface FunctionType<S : FunctionType<S, T>, T : TypeLatticeElement<T>> : TypeLatticeElement<S> {
+    fun withReturnType(returnType: T): S
+
+    fun withParameterTypes(parameterTypes: List<T>): S
+    fun withParameterTypes(parameterTypes: TypeLatticeElementList<T>): S
+
+    fun parameterTypeAt(index: Int): T
+
+    val returnType: T
+
+    val parameterTypes: TypeLatticeElementList<T>
+}
+
+sealed interface CompleteFunctionType<S : FunctionType<S, T>, T : TypeLatticeElement<T>> : FunctionType<S, T> {
+    override fun joinIdentical(other: S): Pair<S, TriState> {
+        val (ret, rIdentical) = returnType.joinIdentical(other.returnType)
+        val (params, pIdentical) = parameterTypes.joinIdentical(other.parameterTypes)
+        return copy(ret, params) to rIdentical.sharpenTowardsNo(pIdentical)
+    }
+
+    override fun withReturnType(returnType: T): S {
+        return copy(returnType, parameterTypes)
+    }
+
+    override fun withParameterTypes(parameterTypes: TypeLatticeElementList<T>): S {
+        return copy(returnType, parameterTypes)
+    }
+
+    override fun parameterTypeAt(index: Int): T {
+        return parameterTypes[index]
+    }
+
+    fun copy(returnType: T, parameterTypes: TypeLatticeElementList<T>): S
+}

--- a/src/main/kotlin/de/sirywell/handlehints/type/MemoryLayoutType.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/MemoryLayoutType.kt
@@ -91,6 +91,9 @@ data class AddressLayoutType(
     }
 }
 
+val WITHOUT_NAME = ExactLayoutName(null)
+val VOID_RETURN_TYPE = NormalValueLayoutType(ExactType.voidType, null, null, WITHOUT_NAME)
+
 data class NormalValueLayoutType(
     val type: Type,
     override val byteAlignment: Long?,
@@ -322,8 +325,6 @@ class IncompleteMemoryLayoutList(knowParameterTypes: SortedMap<Int, MemoryLayout
 
 @TypeInfo(TopLayoutName::class)
 sealed interface LayoutName : TypeLatticeElement<LayoutName>
-
-val WITHOUT_NAME = ExactLayoutName(null)
 
 data class ExactLayoutName(val name: String?) : LayoutName {
     override fun joinIdentical(other: LayoutName): Pair<LayoutName, TriState> {

--- a/src/main/kotlin/de/sirywell/handlehints/type/TypeLatticeElement.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/TypeLatticeElement.kt
@@ -47,6 +47,7 @@ fun topForType(psiType: PsiType, context: PsiElement): TypeLatticeElement<*> {
         methodHandleType(context) -> topForType<MethodHandleType>()
         varHandleType(context) -> topForType<VarHandleType>()
         pathElementType(context) -> topForType<PathElementType>()
+        functionDescriptorType(context) -> topForType<FunctionDescriptorType>()
         in memoryLayoutTypes(context) -> topForType<MemoryLayoutType>()
         else -> throw UnsupportedOperationException("${psiType.presentableText} is not supported")
     }

--- a/src/main/kotlin/de/sirywell/handlehints/type/TypeVisitor.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/type/TypeVisitor.kt
@@ -39,4 +39,7 @@ interface TypeVisitor<C, R> {
     fun visit(type: BotPathElementList, context: C): R
     fun visit(type: CompletePathElementList, context: C): R
     fun visit(type: IncompletePathElementList, context: C): R
+    fun visit(type: CompleteFunctionDescriptorType, context: C): R
+    fun visit(type: TopFunctionDescriptorType, context: C): R
+    fun visit(type: BotFunctionDescriptorType, context: C): R
 }

--- a/src/test/kotlin/de/sirywell/handlehints/mhtype/FunctionDescriptorTest.kt
+++ b/src/test/kotlin/de/sirywell/handlehints/mhtype/FunctionDescriptorTest.kt
@@ -1,0 +1,6 @@
+package de.sirywell.handlehints.mhtype
+
+class FunctionDescriptorTest : TypeAnalysisTestBase() {
+
+    fun testFunctionDescriptorMethods() = doTypeCheckingTest()
+}

--- a/src/test/testData/FunctionDescriptorMethods.java
+++ b/src/test/testData/FunctionDescriptorMethods.java
@@ -1,0 +1,17 @@
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodType;
+
+class FunctionDescriptorMethods {
+
+    void m() {
+        <info descr="([float4])int4">FunctionDescriptor fd00 = <info descr="([float4])int4">FunctionDescriptor.of(ValueLayout.JAVA_INT, <info descr="[float4]">MemoryLayout.structLayout(ValueLayout.JAVA_FLOAT)</info>)</info>;</info>
+        <info descr="([float4])">FunctionDescriptor fd01 = <info descr="([float4])">fd00.dropReturnLayout()</info>;</info>
+        <info descr="([float4]double8)int4">FunctionDescriptor fd02 = <info descr="([float4]double8)int4">fd00.appendArgumentLayouts(ValueLayout.JAVA_DOUBLE)</info>;</info>
+        <info descr="([float4][boolean1|byte1]double8)int4">FunctionDescriptor fd03 = <info descr="([float4][boolean1|byte1]double8)int4">fd02.insertArgumentLayouts(1, <info descr="[boolean1|byte1]">MemoryLayout.unionLayout(ValueLayout.JAVA_BOOLEAN, ValueLayout.JAVA_BYTE)</info>)</info>;</info>
+        <info descr="([float4])char2">FunctionDescriptor fd04 = <info descr="([float4])char2">fd00.changeReturnLayout(ValueLayout.JAVA_CHAR)</info>;</info>
+        <info descr="(MemorySegment)int">MethodType mt00 = <info descr="(MemorySegment)int">fd00.toMethodType()</info>;</info>
+        <info descr="(MemorySegment,MemorySegment,double)int">MethodType mt01 = <info descr="(MemorySegment,MemorySegment,double)int">fd03.toMethodType()</info>;</info>
+    }
+}


### PR DESCRIPTION
`FunctionDescriptor` is a relevant part bridging between `java.lang.invoke` and `java.lang.foreign` APIs.

This PR adds extensive type support. Inspections will follow.