### PR TITLE
feature: quick fix for MethodHandles#constant with zero value

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
@@ -2,6 +2,7 @@ package de.sirywell.handlehints
 
 import com.intellij.codeInspection.dataFlow.CommonDataflow
 import com.intellij.codeInspection.dataFlow.CommonDataflow.DataflowResult
+import com.intellij.codeInspection.dataFlow.types.DfType
 import com.intellij.psi.*
 import com.intellij.psi.impl.source.resolve.reference.impl.JavaReflectionReferenceUtil
 import com.intellij.psi.search.GlobalSearchScope
@@ -122,11 +123,14 @@ val getDataflowResult: MethodHandle = run {
     }
 }
 
-@Suppress("UnstableApiUsage")
 inline fun <reified T> PsiExpression.getConstantOfType(): T? {
+    return getDfType()?.getConstantOfType(T::class.java)
+}
+
+@Suppress("UnstableApiUsage")
+fun PsiExpression.getDfType(): DfType? {
     return (getDataflowResult(this) as DataflowResult?)
         ?.getDfType(this)
-        ?.getConstantOfType(T::class.java)
 }
 
 fun PsiExpression.getConstantLong(): Long? {

--- a/src/main/resources/messages/MethodHandleMessages.properties
+++ b/src/main/resources/messages/MethodHandleMessages.properties
@@ -9,6 +9,7 @@ problem.invocation.returnType.fix.introduce.variable=Insert variable
 problem.invocation.returnType.wrong.cast=Method call requires an explicit cast to {0} but got a cast to {1}.
 problem.invocation.arguments.wrong.types=There are arguments with wrong static types. Expected {0} but got {1}.
 problem.creation.arguments.invalid.type=Parameter must not be of type {0}.
+problem.creation.constant.zero=Usage of 'constant' with zero value can be replaced with 'zero'.
 problem.general.parameters.expected.type=Expected parameter of type {0} but got {1}.
 problem.general.parameters.noParameter=MethodHandle type does not have a parameter but requires at least one.
 problem.general.position.invalidIndexKnownBoundsExcl=Position argument value {0} is out of bounds [0, {1}).

--- a/src/test/kotlin/de/sirywell/handlehints/mhtype/MethodHandleInspectionsTest.kt
+++ b/src/test/kotlin/de/sirywell/handlehints/mhtype/MethodHandleInspectionsTest.kt
@@ -46,6 +46,8 @@ class MethodHandleInspectionsTest : TypeAnalysisTestBase() {
 
     fun testMethodHandlesCollectArguments() = doTypeCheckingTest(true)
 
+    fun testMethodHandlesConstantWithZero() = doInspectionTest()
+
     fun testMethodHandlesDropArguments() = doTypeCheckingTest()
 
     fun testMethodHandlesDropReturn() = doTypeCheckingTest()

--- a/src/test/testData/MethodHandlesConstantWithZero.java
+++ b/src/test/testData/MethodHandlesConstantWithZero.java
@@ -1,0 +1,18 @@
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+
+class MethodHandlesConstantWithZero {
+  void m() {
+    MethodHandle mh00 = <warning descr="Usage of 'constant' with zero value can be replaced with 'zero'.">MethodHandles.constant(int.class, 0)</warning>;
+    MethodHandle mh01 = <warning descr="Usage of 'constant' with zero value can be replaced with 'zero'.">MethodHandles.constant(int.class, '\0')</warning>;
+    MethodHandle mh02 = <warning descr="Usage of 'constant' with zero value can be replaced with 'zero'.">MethodHandles.constant(String.class, null)</warning>;
+    MethodHandle mh03 = <warning descr="Usage of 'constant' with zero value can be replaced with 'zero'.">MethodHandles.constant(Integer.class, null)</warning>;
+    MethodHandle mh04 = <warning descr="Usage of 'constant' with zero value can be replaced with 'zero'.">MethodHandles.constant(boolean.class, false)</warning>;
+    MethodHandle mh05 = <warning descr="Usage of 'constant' with zero value can be replaced with 'zero'.">MethodHandles.constant(char.class, (char) ('a' - 'a'))</warning>;
+    MethodHandle mh06 = <warning descr="Usage of 'constant' with zero value can be replaced with 'zero'.">MethodHandles.constant(long.class, 0)</warning>;
+    MethodHandle mh07 = <warning descr="Usage of 'constant' with zero value can be replaced with 'zero'.">MethodHandles.constant(long.class, 0L)</warning>;
+    MethodHandle mh08 = <warning descr="Usage of 'constant' with zero value can be replaced with 'zero'.">MethodHandles.constant(byte.class, (byte) 0)</warning>;
+    MethodHandle mh09 = <warning descr="Usage of 'constant' with zero value can be replaced with 'zero'.">MethodHandles.constant(short.class, (short) 0)</warning>;
+  }
+}

--- a/src/test/testData/WrongArgumentTypeInConstant.java
+++ b/src/test/testData/WrongArgumentTypeInConstant.java
@@ -5,8 +5,8 @@ class WrongArgumentTypeInConstant {
   private static final MethodHandle a = MethodHandles.constant(byte.class, <warning descr="Expected parameter of type byte but got int.">0</warning>);
   private static final MethodHandle b = MethodHandles.constant(int.class, <warning descr="Expected parameter of type int but got String.">"Hello World"</warning>); // CCE
   private static final MethodHandle c = MethodHandles.constant(byte.class, <warning descr="Expected parameter of type byte but got int.">0</warning>); // CCE
-  private static final MethodHandle d = MethodHandles.constant(byte.class, (byte) 0); // fine
-  private static final MethodHandle e = MethodHandles.constant(int.class, (byte) 0); // fine
+  private static final MethodHandle d = MethodHandles.constant(byte.class, (byte) 1); // fine
+  private static final MethodHandle e = MethodHandles.constant(int.class, (byte) 1); // fine
   private static final MethodHandle f = MethodHandles.constant(CharSequence.class, "Hello"); // fine
   private static final MethodHandle g = MethodHandles.constant(String.class, (CharSequence) "a"); // fine
   private static final MethodHandle h = MethodHandles.constant(String.class, <warning descr="Expected parameter of type String but got Integer.">Integer.valueOf(1)</warning>); // CCE


### PR DESCRIPTION
`MethodHandles.constant(...)` can be replaced with `MethodHandles.zero(...)` if the passed constant is the zero value of the given type.