### PR TITLE
chore: bump maximum supported IntelliJ platform version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ pluginVersion = 0.2.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233
-pluginUntilBuild = 242.*
+pluginUntilBuild = 243.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#intellij-extension
 platformType = IC
@@ -19,7 +19,7 @@ platformVersion = 2023.3
 platformPlugins = com.intellij.java
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.7
+gradleVersion = 8.10.2
 
 # Opt-out flag for bundling Kotlin standard library -> https://plugins.jetbrains.com/docs/intellij/kotlin.html#kotlin-standard-library
 # suppress inspection "UnusedProperty"


### PR DESCRIPTION
IJ 2024.3 already has EA builds, so we should prepare to support that version.