### PR TITLE
feature: warn on void MethodType parameters

### DIFF
--- a/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
+++ b/src/main/kotlin/de/sirywell/handlehints/psiSupport.kt
@@ -139,8 +139,8 @@ fun PsiExpression.getConstantLong(): Long? {
 }
 
 
-fun Collection<PsiExpression>.mapToTypes(): List<Type> {
-    return this.map { element -> element.asType() }
+fun Collection<PsiExpression>.mapToTypes(check: (PsiExpression, Type) -> Type = { _, t -> t}): List<Type> {
+    return this.map { element -> check(element, element.asType()) }
 }
 
 fun PsiExpression.asType(): Type {

--- a/src/test/kotlin/de/sirywell/handlehints/mhtype/MethodHandleInspectionsTest.kt
+++ b/src/test/kotlin/de/sirywell/handlehints/mhtype/MethodHandleInspectionsTest.kt
@@ -64,15 +64,15 @@ class MethodHandleInspectionsTest : TypeAnalysisTestBase() {
 
     fun testMethodHandleWithVarargs() = doInspectionAndTypeCheckingTest()
 
-    fun testMethodTypeAppendParameterTypes() = doTypeCheckingTest()
+    fun testMethodTypeAppendParameterTypes() = doInspectionAndTypeCheckingTest()
 
-    fun testMethodTypeChangeParameterType() = doTypeCheckingTest()
+    fun testMethodTypeChangeParameterType() = doInspectionAndTypeCheckingTest()
 
     fun testMethodTypeChangeReturnType() = doTypeCheckingTest()
 
     fun testMethodTypeCreateBasic() = doTypeCheckingTest()
 
-    fun testMethodTypeCreateWithParameters() = doTypeCheckingTest()
+    fun testMethodTypeCreateWithParameters() = doInspectionAndTypeCheckingTest()
 
     fun testMethodTypeDropParameterTypes() = doTypeCheckingTest()
 
@@ -82,7 +82,7 @@ class MethodHandleInspectionsTest : TypeAnalysisTestBase() {
 
     fun testMethodTypeGenericMethodType() = doTypeCheckingTest()
 
-    fun testMethodTypeInsertParameterTypes() = doTypeCheckingTest()
+    fun testMethodTypeInsertParameterTypes() = doInspectionAndTypeCheckingTest()
 
     fun testMethodTypeWrap() = doTypeCheckingTest()
 

--- a/src/test/testData/MethodTypeAppendParameterTypes.java
+++ b/src/test/testData/MethodTypeAppendParameterTypes.java
@@ -4,4 +4,9 @@ import java.lang.invoke.MethodType;
 
 class MethodTypeAppendParameterTypes {
   <info descr="(boolean,String,double)int">private static final MethodType A = <info descr="(boolean,String,double)int"><info descr="(boolean)int">MethodType.methodType(int.class, boolean.class)</info>.appendParameterTypes(String.class, double.class)</info>;</info>
+  void append() {
+    <info descr="()void">MethodType mt30 = <info descr="()void">MethodType.methodType(void.class)</info>;</info>
+    <info descr="(⊤)void">MethodType mt31 = <info descr="(⊤)void">mt30.appendParameterTypes(<warning descr="Type must not be void.">void.class</warning>)</info>;</info>
+    <info descr="(int,⊤,double,⊤)void">MethodType mt32 = <info descr="(int,⊤,double,⊤)void">mt30.appendParameterTypes(int.class, <warning descr="Type must not be void.">void.class</warning>, double.class, <warning descr="Type must not be void.">void.class</warning>)</info>;</info>
+  }
 }

--- a/src/test/testData/MethodTypeChangeParameterType.java
+++ b/src/test/testData/MethodTypeChangeParameterType.java
@@ -5,4 +5,7 @@ import java.lang.invoke.MethodType;
 class MethodTypeChangeParameterType {
   <info descr="(double,int)void">private static final MethodType A = <info descr="(double,int)void"><info descr="(boolean,int)void">MethodType.methodType(void.class, boolean.class, int.class)</info>.changeParameterType(0, double.class)</info>;</info>
   <info descr="(boolean,double)void">private static final MethodType B = <info descr="(boolean,double)void"><info descr="(boolean,int)void">MethodType.methodType(void.class, boolean.class, int.class)</info>.changeParameterType(1, double.class)</info>;</info>
+  void change(MethodType unknown) {
+    <info descr="⊤">MethodType mt40 = <info descr="⊤">unknown.changeParameterType(0, <warning descr="Type must not be void.">void.class</warning>)</info>;</info>
+  }
 }

--- a/src/test/testData/MethodTypeCreateWithParameters.java
+++ b/src/test/testData/MethodTypeCreateWithParameters.java
@@ -2,6 +2,9 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 
-class MethodTypeWrap {
+class MethodTypeCreateWithParameters {
   <info descr="(int,float)void">private static final MethodType A = <info descr="(int,float)void">MethodType.methodType(void.class, <info descr="(int,float)String">MethodType.methodType(String.class, int.class, float.class)</info>)</info>;</info>
+  void create() {
+    <info descr="(⊤)void">MethodType mt00 = <info descr="(⊤)void">MethodType.methodType(void.class, <warning descr="Type must not be void.">void.class</warning>)</info>;</info>
+  }
 }

--- a/src/test/testData/MethodTypeInsertParameterTypes.java
+++ b/src/test/testData/MethodTypeInsertParameterTypes.java
@@ -4,4 +4,9 @@ import java.lang.invoke.MethodType;
 
 class MethodTypeInsertParameterTypes {
   <info descr="(boolean,int,double,float,long)void">private static final MethodType A = <info descr="(boolean,int,double,float,long)void"><info descr="(boolean,float,long)void">MethodType.methodType(void.class, boolean.class, float.class, long.class)</info>.insertParameterTypes(1, int.class, double.class)</info>;</info>
+  void insert() {
+    <info descr="()void">MethodType mt20 = <info descr="()void">MethodType.methodType(void.class)</info>;</info>
+    <info descr="(⊤)void">MethodType mt21 = <info descr="(⊤)void">mt20.insertParameterTypes(0, <warning descr="Type must not be void.">void.class</warning>)</info>;</info>
+    <info descr="(int,⊤)void">MethodType mt22 = <info descr="(int,⊤)void">mt20.insertParameterTypes(0, int.class, <warning descr="Type must not be void.">void.class</warning>)</info>;</info>
+  }
 }


### PR DESCRIPTION
`void.class` as argument to a parameter list of a `MethodType` is not allowed and should produce a warning.