### PR TITLE
chore: make renovate update gradle version in gradle.properties

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,18 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "datasourceTemplate": "gradle",
+      "packageNameTemplate": "gradle-wrapper",
+      "fileMatch": [
+        "(^|/)gradle.properties$"
+      ],
+      "matchStrings": [
+        "gradleVersion ?= ?(?<currentValue>[^ #])"
+      ]
+    }
   ]
 }


### PR DESCRIPTION
Renovate currently only updates the distribution url, but the gradleVersion in gradle.properties stays outdated. Let's try to fix that.